### PR TITLE
Add config_flow for configuration via Integrations UI

### DIFF
--- a/custom_components/solarman/__init__.py
+++ b/custom_components/solarman/__init__.py
@@ -1,1 +1,36 @@
 """The Solarman Collector integration."""
+
+import logging
+
+from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_NAME
+
+from .const import *
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORMS: list[str] = ["sensor"]
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Solarman Collector from a config entry."""
+    _LOGGER.debug(f'__init__.py:async_setup_entry({entry.as_dict()})')
+    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    entry.async_on_unload(entry.add_update_listener(update_listener))
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    _LOGGER.debug(f'__init__.py:async_unload_entry({entry.as_dict()})')
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+    return unload_ok
+
+
+async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Handle options update."""
+    _LOGGER.debug(f'__init__.py:update_listener({entry.as_dict()})')
+    hass.data[DOMAIN][entry.entry_id].config(entry)
+    entry.title = entry.options[CONF_NAME]

--- a/custom_components/solarman/config_flow.py
+++ b/custom_components/solarman/config_flow.py
@@ -1,0 +1,159 @@
+"""Config flow for SolarMAN logger integration."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+from socket import getaddrinfo, herror, gaierror, timeout
+
+import voluptuous as vol
+from voluptuous.schema_builder import Schema
+
+from homeassistant import config_entries
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.exceptions import HomeAssistantError
+
+from homeassistant.const import (EVENT_HOMEASSISTANT_STOP, CONF_NAME, CONF_SCAN_INTERVAL)
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from .const import *
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def step_user_data_schema(data: dict[str, Any] = {CONF_NAME: SENSOR_PREFIX, CONF_INVERTER_PORT: DEFAULT_PORT_INVERTER, CONF_LOOKUP_FILE: DEFAULT_LOOKUP_FILE}) -> Schema:
+    _LOGGER.debug(f'config_flow.py:step_user_data_schema: {data}')
+    STEP_USER_DATA_SCHEMA = vol.Schema(
+        {
+            vol.Required(CONF_NAME, default=data.get(CONF_NAME)): str,
+            vol.Required(CONF_INVERTER_HOST, default=data.get(CONF_INVERTER_HOST)): str,
+            vol.Required(CONF_INVERTER_PORT, default=data.get(CONF_INVERTER_PORT)): int,
+            vol.Required(CONF_INVERTER_SERIAL, default=data.get(CONF_INVERTER_SERIAL)): int,
+            vol.Optional(CONF_LOOKUP_FILE, default=data.get(CONF_LOOKUP_FILE)): vol.In(LOOKUP_FILES),
+        },
+        extra=vol.PREVENT_EXTRA
+    )
+    _LOGGER.debug(
+        f'config_flow.py:step_user_data_schema: STEP_USER_DATA_SCHEMA: {STEP_USER_DATA_SCHEMA}')
+    return STEP_USER_DATA_SCHEMA
+
+
+async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
+    """
+    Validate the user input allows us to connect.
+
+    Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
+    """
+
+    _LOGGER.debug(f'config_flow.py:validate_input: {data}')
+
+    try:
+        getaddrinfo(
+            data[CONF_INVERTER_HOST], data[CONF_INVERTER_PORT], family=0, type=0, proto=0, flags=0
+        )
+    except herror:
+        raise InvalidHost
+    except gaierror:
+        raise CannotConnect
+    except timeout:
+        raise CannotConnect
+
+    return {"title": data[CONF_INVERTER_HOST]}
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for SolarMAN logger."""
+
+    VERSION = 1
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(entry: config_entries.ConfigEntry) -> OptionsFlow:
+        """Get the options flow for this handler."""
+        _LOGGER.debug(f'config_flow.py:ConfigFlow.async_get_options_flow: {entry}')
+        return OptionsFlow(entry)
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        _LOGGER.debug(f'config_flow.py:ConfigFlow.async_step_user: {user_input}')
+        """Handle the initial step."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="user", data_schema=step_user_data_schema()
+            )
+
+        errors = {}
+
+        try:
+            info = await validate_input(self.hass, user_input)
+        except InvalidHost:
+            errors["base"] = "invalid_host"
+        except CannotConnect:
+            errors["base"] = "cannot_connect"
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception("Unexpected exception")
+            errors["base"] = "unknown"
+        else:
+            _LOGGER.debug(f'config_flow.py:ConfigFlow.async_step_user: validation passed: {user_input}')
+            # await self.async_set_unique_id(user_input.device_id) # not sure this is permitted as the user can change the device_id
+            # self._abort_if_unique_id_configured()
+            return self.async_create_entry(
+                title=info["title"], data=user_input, options=user_input
+            )
+
+        _LOGGER.debug(f'config_flow.py:ConfigFlow.async_step_user: validation failed: {user_input}')
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=step_user_data_schema(user_input),
+            errors=errors,
+        )
+
+
+class OptionsFlow(config_entries.OptionsFlow):
+    """Handle options."""
+
+    def __init__(self, entry: config_entries.ConfigEntry) -> None:
+        """Initialize options flow."""
+        _LOGGER.debug(f'config_flow.py:OptionsFlow.__init__: {entry}')
+        self.entry = entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Manage the options."""
+        _LOGGER.debug(f'config_flow.py:OptionsFlow.async_step_init: {user_input}')
+        if user_input is None:
+            return self.async_show_form(
+                step_id="init",
+                data_schema=step_user_data_schema(self.entry.options),
+            )
+
+        errors = {}
+
+        try:
+            info = await validate_input(self.hass, user_input)
+        except InvalidHost:
+            errors["base"] = "invalid_host"
+        except CannotConnect:
+            errors["base"] = "cannot_connect"
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception("Unexpected exception")
+            errors["base"] = "unknown"
+        else:
+            return self.async_create_entry(title=info["title"], data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=step_user_data_schema(user_input),
+            errors=errors,
+        )
+
+
+class CannotConnect(HomeAssistantError):
+    """Error to indicate we cannot connect."""
+
+
+class InvalidHost(HomeAssistantError):
+    """Error to indicate there is invalid hostname or IP address."""

--- a/custom_components/solarman/const.py
+++ b/custom_components/solarman/const.py
@@ -1,7 +1,11 @@
 from datetime import timedelta
 
+DOMAIN = 'solarman'
 
 DEFAULT_PORT_INVERTER = 8899
+DEFAULT_LOOKUP_FILE = 'parameters.yaml'
+LOOKUP_FILES = ['parameters.yaml', 'sofar_lsw3.yaml', 'deye_string.yaml']
+
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=30)
 
 CONF_INVERTER_HOST = 'inverter_host'

--- a/custom_components/solarman/manifest.json
+++ b/custom_components/solarman/manifest.json
@@ -3,6 +3,7 @@
   "name": "Solarman",
   "documentation": "https://github.com/StephanJoubert/home_assistant_solarman/blob/main/README.md",
   "version": "1.0.0",
+  "config_flow": true,
   "dependencies": [],
   "codeowners": ["@StephanJoubert"],
   "issue_tracker": "https://github.com/StephanJoubert/home_assistant_solarman/issues",

--- a/custom_components/solarman/sensor.py
+++ b/custom_components/solarman/sensor.py
@@ -2,61 +2,58 @@
 ################################################################################
 #   Solarman local interface.
 #
-#   This component can retrieve data from the solarman dongle using version 5 
+#   This component can retrieve data from the solarman dongle using version 5
 #   of the protocol.
 #
 ###############################################################################
 
 from datetime import datetime
 
+import logging
 import voluptuous as vol
-from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import ( EVENT_HOMEASSISTANT_STOP, CONF_NAME, CONF_SCAN_INTERVAL )
-import homeassistant.helpers.config_validation as cv
-from homeassistant.util import Throttle
-from homeassistant.helpers.entity import Entity, generate_entity_id
-
+from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_NAME
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import *
 from .solarman import Inverter
 
+_LOGGER = logging.getLogger(__name__)
 
-def _check_config_schema(conf):
-    return conf
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback):
+    _LOGGER.debug(f'sensor.py:async_setup_entry: {entry.options}')
 
-PLATFORM_SCHEMA = vol.All(PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_NAME, default=SENSOR_PREFIX): cv.string,
-    vol.Required(CONF_INVERTER_HOST, default=None): cv.string,
-    vol.Required(CONF_INVERTER_PORT, default=DEFAULT_PORT_INVERTER): cv.positive_int,
-    vol.Required(CONF_INVERTER_SERIAL, default=None): cv.positive_int,
-    vol.Optional(CONF_LOOKUP_FILE): cv.string,
-}, extra=vol.PREVENT_EXTRA), _check_config_schema)        
+    inverter_name = entry.options.get(CONF_NAME)
+    inverter_host = entry.options.get(CONF_INVERTER_HOST)
+    inverter_port = entry.options.get(CONF_INVERTER_PORT)
+    inverter_sn = entry.options.get(CONF_INVERTER_SERIAL)
+    lookup_file = entry.options.get(CONF_LOOKUP_FILE)
+    path = hass.config.path('custom_components/solarman/')
 
-def setup_platform(hass, config, add_devices, discovery_info=None):
-  inverter_name = config.get(CONF_NAME)
-  inverter_host = config.get(CONF_INVERTER_HOST)
-  inverter_port = config.get(CONF_INVERTER_PORT)
-  inverter_sn = config.get(CONF_INVERTER_SERIAL)
-  lookup_file = config.get(CONF_LOOKUP_FILE)
-  path=hass.config.path('custom_components/solarman/')
-  # Check input configuration. 
-  if(inverter_host == None):
-    raise vol.Invalid('configuration parameter [inverter_host] does not have a value')
-  if(inverter_sn == None):
-    raise vol.Invalid('configuration parameter [inverter_serial] does not have a value')
-   
-  inverter = Inverter(path, inverter_sn, inverter_host, inverter_port, lookup_file)
-  #  Prepare the sensor entities.
-  hass_sensors = []
-  for sensor in inverter.get_sensors():
-      if "isstr" in sensor:
-        hass_sensors.append(SunsynkSensorText(inverter_name, inverter, sensor, inverter_sn))
-      else:
-        hass_sensors.append(SunsynkSensor(inverter_name, inverter, sensor, inverter_sn))
+    # Check input configuration.
+    if inverter_host is None:
+        raise vol.Invalid('configuration parameter [inverter_host] does not have a value')
+    if inverter_sn is None:
+        raise vol.Invalid('configuration parameter [inverter_serial] does not have a value')
 
-  hass_sensors.append(SynsynkStatus(inverter_name, inverter, "status_lastUpdate", inverter_sn))
-  hass_sensors.append(SynsynkStatus(inverter_name, inverter, "status_connection", inverter_sn))  
-  add_devices(hass_sensors)
+    inverter = Inverter(path, inverter_sn, inverter_host, inverter_port, lookup_file)
+    #  Prepare the sensor entities.
+    hass_sensors = []
+    for sensor in inverter.get_sensors():
+        if "isstr" in sensor:
+            hass_sensors.append(SunsynkSensorText(inverter_name, inverter, sensor, inverter_sn))
+        else:
+            hass_sensors.append(SunsynkSensor(inverter_name, inverter, sensor, inverter_sn))
+
+    hass_sensors.append(SynsynkStatus(inverter_name, inverter, "status_lastUpdate", inverter_sn))
+    hass_sensors.append(SynsynkStatus(inverter_name, inverter, "status_connection", inverter_sn))
+
+    _LOGGER.debug(f'sensor.py:async_setup_entry: async_add_entities')
+    _LOGGER.debug(hass_sensors)
+
+    async_add_entities(hass_sensors)
 
 #############################################################################################################
 # This is the entity seen by Home Assistant.
@@ -64,35 +61,35 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 #############################################################################################################
 
 class SynsynkStatus(Entity):
-    def __init__(self,inverter_name, inverter, field_name, sn):
+    def __init__(self, inverter_name, inverter, field_name, sn):
         self._inverter_name = inverter_name
         self.inverter = inverter
         self._field_name = field_name
         self.p_state = None
         self.p_icon = 'mdi:magnify'
-        self._sn = sn        
-        return        
-    
+        self._sn = sn
+        return
+
     @property
     def icon(self):
         #  Return the icon of the sensor. """
-        return self.p_icon    
-   
+        return self.p_icon
+
     @property
     def name(self):
-        #  Return the name of the sensor. 
+        #  Return the name of the sensor.
         return "{} {}".format(self._inverter_name, self._field_name)
-    
+
     @property
     def unique_id(self):
         # Return a unique_id based on the serial number
-        return "{}_{}_{}".format(self._inverter_name, self._sn, self._field_name)   
+        return "{}_{}_{}".format(self._inverter_name, self._sn, self._field_name)
 
     @property
     def state(self):
-        #  Return the state of the sensor. 
-        return self.p_state     
-    
+        #  Return the state of the sensor.
+        return self.p_state
+
     def update(self):
         self.p_state = getattr(self.inverter, self._field_name)
 
@@ -110,22 +107,22 @@ class SunsynkSensorText(SynsynkStatus):
             self.p_icon = ''
         return
 
- 
+
     def update(self):
-    #  Update this sensor using the data. 
-    #  Get the latest data and use it to update our sensor state. 
+    #  Update this sensor using the data.
+    #  Get the latest data and use it to update our sensor state.
     #  Retrieve the sensor data from actual interface
         self.inverter.update()
 
         val = self.inverter.get_current_val()
         if val is not None:
-            if self._field_name in val:           
+            if self._field_name in val:
                 self.p_state = val[self._field_name]
-                
-                
+
+
 #############################################################################################################
 #  Entity displaying a numeric field read from the inverter
-#   Overrides the Text sensor and supply the device class, last_reset and unit of measurement 
+#   Overrides the Text sensor and supply the device class, last_reset and unit of measurement
 #############################################################################################################
 
 
@@ -139,18 +136,18 @@ class SunsynkSensor(SunsynkSensorText):
             self._state_class = None
         self.uom = sensor['uom']
         return
-        
+
     @property
     def device_class(self):
         return self._device_class
-        
-        
+
+
     @property
-    def extra_state_attributes(self): 
+    def extra_state_attributes(self):
         if self._state_class:
             return  {
                 'state_class': self._state_class
-            }   
+            }
         else:
             return None
 

--- a/custom_components/solarman/strings.json
+++ b/custom_components/solarman/strings.json
@@ -1,0 +1,23 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_host%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "name": "[%key:common::config_flow::step::user::data::name%]",
+          "inverter_host": "[%key:common::config_flow::step::user::data::inverter_host%]",
+          "inverter_port": "[%key:common::config_flow::step::user::data::inverter_port%]",
+          "inverter_serial": "[%key:common::config_flow::step::user::data::inverter_serial%]",
+          "lookup_file": "[%key:common::config_flow::step::user::data::lookup_file%]"
+        }
+      }
+    }
+  }
+}

--- a/custom_components/solarman/translations/en.json
+++ b/custom_components/solarman/translations/en.json
@@ -1,0 +1,24 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "Device is already configured"
+    },
+    "error": {
+      "cannot_connect": "Failed to connect",
+      "invalid_host": "Invalid hostname or IP address",
+      "unknown": "Unexpected error"
+    },
+    "step": {
+      "user": {
+        "title": "Inverter connection configuration",
+        "data": {
+          "name": "This name will be prefixed to all parameter values (change as you like)",
+          "inverter_host": "Host (ip or hostname)",
+          "inverter_port": "Port (usually 8899)",
+          "inverter_serial": "Device Serial Number (retrieve from the web interface)",
+          "lookup_file": "The yaml file to use for parameter-definition"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Mostly taken from my own attempt at creating the same custom component - https://github.com/YodaDaCoda/hass-solarman-modbus/

I note that your README.md includes a configuration parameter `scan_interval` which appears unused. I've not attempted to add that parameter.

NB: during config flow, a connection attempt is made to the specified host/port combination. If this fails (e.g. because you're setting it up at night and the inverter/sensor is powered off) then setup will fail and the integration will not be added.

Fixes #15

My editor also removed some excess whitespace, I hope that's not an issue.