### PR TITLE
Fix zero values on total production lead to wrong error counting

### DIFF
--- a/custom_components/solarman/inverter_definitions/deye_string.yaml
+++ b/custom_components/solarman/inverter_definitions/deye_string.yaml
@@ -59,6 +59,7 @@ parameters:
       rule: 3
       registers: [0x003F,0x0040]
       icon: 'mdi:solar-power'
+      invalid: 0.0
 
 
 

--- a/custom_components/solarman/parser.py
+++ b/custom_components/solarman/parser.py
@@ -1,5 +1,6 @@
 import yaml
 import struct
+import math
 
 
 
@@ -71,7 +72,11 @@ class ParameterParser:
             if self.is_integer_num (value):
                 self.result[title] = int(value)  
             else:   
-                self.result[title] = value  
+                self.result[title] = value
+
+            if 'invalid' in definition:
+                if math.fabs(definition['invalid'] - value) < 0.001:
+                    raise ValueError(f'Invalidate complete dataset ({title} ~ {value})')
         return
     
     def try_parse_unsigned (self, rawData, definition, start, length):
@@ -100,7 +105,11 @@ class ParameterParser:
                 if self.is_integer_num (value):
                     self.result[title] = int(value)  
                 else:   
-                    self.result[title] = value                  
+                    self.result[title] = value   
+
+                if 'invalid' in definition:
+                    if math.fabs(definition['invalid'] - value) < 0.001:
+                        raise ValueError(f'Invalidate complete dataset ({title} ~ {value})')
         return
 
 

--- a/custom_components/solarman/solarman.py
+++ b/custom_components/solarman/solarman.py
@@ -167,6 +167,7 @@ class Inverter:
                 params.parse(raw_msg, start, length) 
             del raw_msg
         except:
+            logging.exception("An exception was thrown!")
             result = 0
         finally:
             sock.close()   

--- a/customization.md
+++ b/customization.md
@@ -75,6 +75,7 @@ The group just groups parameters that belong together. The induvidual parameter-
 |rule|Method to interpret the data from the logger ###|
 |registers|Array of register fields that comprises the value. If the value is placed in a number of registers, this  array will contain more than one item.|
 |lookup|Defines a key-value pair for values where an integer maps to a string field|
+|invalid|Optional validation against a reference value, which invalidate complete dataset. Could be used, if the inverter delivers sometimes non usable data (e.g. Total Production == 0.0)|
 
 
 \# (see) https://developers.home-assistant.io/docs/core/entity/


### PR DESCRIPTION
This fixes https://github.com/StephanJoubert/home_assistant_solarman/issues/111

This introduce "invalid" option to parser, so that the complete dataset could be ignored,
when e.g. "Total Production" is zero during startup of the inverter.