### PR TITLE
Use logger for this domain

### DIFF
--- a/custom_components/solarman/solarman.py
+++ b/custom_components/solarman/solarman.py
@@ -167,7 +167,7 @@ class Inverter:
                 params.parse(raw_msg, start, length) 
             del raw_msg
         except:
-            logging.exception("An exception was thrown!")
+            log.error("An exception was thrown!")
             result = 0
         finally:
             sock.close()   


### PR DESCRIPTION
Previously the logger published the exception as an general error. Now it uses the logger defined in line 10. With this added in the `configuration.yaml`:
```
logger:
  default: error
  logs:
    custom_components.solarman: fatal
```
the error isn't showing anymore. Solves #175