### PR TITLE
LSW3: remove unused register range

### DIFF
--- a/custom_components/solarman/inverter_definitions/sofar_lsw3.yaml
+++ b/custom_components/solarman/inverter_definitions/sofar_lsw3.yaml
@@ -2,9 +2,6 @@ requests:
   - start: 0x0000
     end:  0x0027
     mb_functioncode: 0x03
-  - start: 0x0105
-    end: 0x0114
-    mb_functioncode: 0x03
 
 
 parameters:


### PR DESCRIPTION
See https://github.com/StephanJoubert/home_assistant_solarman/issues/187

* I don't see the register range `0x0105` to `0x0114` used in the file for any actual data point
* As per https://github.com/StephanJoubert/home_assistant_solarman/issues/187 it seems that querying for it, breaks data fetching since https://github.com/StephanJoubert/home_assistant_solarman/pull/125 (rightfully, given the packet validation does the right thing here...)