### PR TITLE
bugfix: retry mechanism

### DIFF
--- a/custom_components/solarman/solarman.py
+++ b/custom_components/solarman/solarman.py
@@ -183,11 +183,12 @@ class Inverter:
         log.debug(f"Starting to query for [{len(requests)}] ranges...")
 
         def connect_to_server():
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            sock.settimeout(6)
-            sock.connect((self._host, self._port))
-            return sock
+            server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            server.settimeout(6)
+            server.connect((self._host, self._port))
+            return server
 
+        sock = None
         try:
             sock = connect_to_server()
 
@@ -231,7 +232,8 @@ class Inverter:
             log.warning(f"Querying failed on connection start with exception [{type(e).__name__}]")
             self.status_connection = "Disconnected"
         finally:
-            sock.close()
+            if sock:
+                sock.close()
 
     def get_current_val(self):
         return self._current_val


### PR DESCRIPTION
See https://github.com/StephanJoubert/home_assistant_solarman/issues/187

* only close socket if it was ever opened successfully
* this is only the bug-fix of #194 without the partial roll-back, as it seems we do not them it

Fixing stack traces a la as reported by @heebo1974 
```
  File "/usr/src/homeassistant/homeassistant/util/__init__.py", line 192, in wrapper
    result = method(*args, **kwargs)
  File "/config/custom_components/solarman/solarman.py", line 175, in update
    self.get_statistics()
  File "/config/custom_components/solarman/solarman.py", line 234, in get_statistics
    sock.close()
UnboundLocalError: local variable 'sock' referenced before assignment
```