### PR TITLE
fix: don't error if socket doesn't connect

### DIFF
--- a/custom_components/solarman/solarman.py
+++ b/custom_components/solarman/solarman.py
@@ -31,9 +31,9 @@ class Inverter:
         elif lookup_file == 'parameters.yaml':
             lookup_file = 'deye_hybrid.yaml'
 
-            
+
         with open(self.path + lookup_file) as f:
-            self.parameter_definition = yaml.full_load(f) 
+            self.parameter_definition = yaml.full_load(f)
 
     def modbus(self, data):
         POLY = 0xA001
@@ -44,23 +44,23 @@ class Inverter:
             for _ in range(8):
                 crc = ((crc >> 1) ^ POLY
                 if (crc & 0x0001)
-                else crc >> 1)  
-        return crc    
+                else crc >> 1)
+        return crc
 
     def get_serial_hex(self):
         serial_hex = hex(self._serial)[2:]
         serial_bytes = bytearray.fromhex(serial_hex)
         serial_bytes.reverse()
         return serial_bytes
-    
+
     def get_read_business_field(self, start, length, mb_fc):
         request_data = bytearray([self._mb_slaveid, mb_fc]) # Function Code
         request_data.extend(start.to_bytes(2, 'big'))
         request_data.extend(length.to_bytes(2, 'big'))
         crc = self.modbus(request_data)
-        request_data.extend(crc.to_bytes(2, 'little'))  
+        request_data.extend(crc.to_bytes(2, 'little'))
         return request_data
-        
+
     def generate_request(self, start, length, mb_fc):
         packet = bytearray([START_OF_MESSAGE])
 
@@ -69,19 +69,19 @@ class Inverter:
         buisiness_field = self.get_read_business_field(start, length, mb_fc)
         packet_data.extend(buisiness_field)
         length = packet_data.__len__()
-        packet.extend(length.to_bytes(2, "little")) 
+        packet.extend(length.to_bytes(2, "little"))
         packet.extend(CONTROL_CODE)
         packet.extend(SERIAL_NO)
-        packet.extend(self.get_serial_hex())    
+        packet.extend(self.get_serial_hex())
         packet.extend(packet_data)
         #Checksum
         checksum = 0
         for i in range(1,len(packet),1):
             checksum += packet[i]
         packet.append(checksum & 0xFF)
-        packet.append(END_OF_MESSAGE)  
-        
-        del packet_data      
+        packet.append(END_OF_MESSAGE)
+
+        del packet_data
         del buisiness_field
         return packet
 
@@ -230,7 +230,7 @@ class Inverter:
             else:
                 self.status_connection = "Disconnected"
         except Exception as e:
-            log.warning(f"Querying failed on connection start with exception [{type(e).__name__}]")
+            log.warning(f"Querying inverter {self._serial} at {self._host}:{self._port} failed on connection start with exception [{type(e).__name__}]")
             self.status_connection = "Disconnected"
         finally:
             if sock:

--- a/custom_components/solarman/solarman.py
+++ b/custom_components/solarman/solarman.py
@@ -188,6 +188,8 @@ class Inverter:
             sock.connect((self._host, self._port))
             return sock
 
+        sock = None
+
         try:
             sock = connect_to_server()
 
@@ -231,7 +233,8 @@ class Inverter:
             log.warning(f"Querying failed on connection start with exception [{type(e).__name__}]")
             self.status_connection = "Disconnected"
         finally:
-            sock.close()
+            if sock:
+                sock.close()
 
     def get_current_val(self):
         return self._current_val


### PR DESCRIPTION
If `connect_to_server()` excepts, `sock` never gets assigned a value, and in fact never gets defined, resulting in a exception that `sock` is referenced before assignment when trying to `sock.close()`.