### PR TITLE
Group Sensors into a Device

### DIFF
--- a/custom_components/solarman/solarman.py
+++ b/custom_components/solarman/solarman.py
@@ -26,14 +26,12 @@ class Inverter:
         self._current_val = None
         self.status_connection = "Disconnected"
         self.status_lastUpdate = "N/A"
-        if not lookup_file:
-            lookup_file = 'deye_hybrid.yaml'
-        elif lookup_file == 'parameters.yaml':
-            lookup_file = 'deye_hybrid.yaml'
+        self.lookup_file = lookup_file
+        if not self.lookup_file or lookup_file == 'parameters.yaml':
+            self.lookup_file = 'deye_hybrid.yaml'
 
-            
-        with open(self.path + lookup_file) as f:
-            self.parameter_definition = yaml.full_load(f) 
+        with open(self.path + self.lookup_file) as f:
+            self.parameter_definition = yaml.full_load(f)
 
     def modbus(self, data):
         POLY = 0xA001


### PR DESCRIPTION
Provides Home Assistant the information it needs to group the Sensors into a single Device, providing a nicer user experience for viewing information about the inverter's stats.

Integrations view:
![image](https://user-images.githubusercontent.com/365349/217665675-5826d250-82c3-4176-97b6-3cda9402907f.png)

Device view:
![image](https://user-images.githubusercontent.com/365349/217665727-8c835d8b-b0c7-4afc-bf3e-4cc270b72b84.png)
