### PR TITLE
Added missing parameters from ZCS AZZURRO 3PH inverters

### DIFF
--- a/custom_components/solarman/inverter_definitions/sofar_g3hyd.yaml
+++ b/custom_components/solarman/inverter_definitions/sofar_g3hyd.yaml
@@ -1,5 +1,6 @@
 # Sofar G3 also HYD 5-20KTL-3PH
-# some value commented after month no change
+# This works also for rebranded ZCS Azzurro 3-Phase inverters such as the 3PH HYD6000 ZSS
+# Note that this won't work if your ZCS inverter is connected via Connext, you have to be using a Wi-Fi or Ethernet Kit such as ZSM-WIFI-USB.
 requests:
   - start: 0x0404
     end: 0x0420
@@ -21,6 +22,7 @@ requests:
     end: 0x069B
     mb_functioncode: 0x03
 parameters:
+
   - group: Inverter
     items:
       - name: "Inverter status"
@@ -56,12 +58,54 @@ parameters:
         rule: 2
         registers: [ 0x0418 ]
         icon: 'mdi:thermometer'
+      - name: "Ambient temperature 2"
+        class: "temperature"
+        uom: "°C"
+        scale: 1
+        rule: 2
+        registers: [ 0x0419 ]
+        icon: 'mdi:thermometer'
       - name: "Radiator temperature 1"
         class: "temperature"
         uom: "°C"
         scale: 1
         rule: 2
         registers: [ 0x041A ]
+        icon: 'mdi:thermometer'
+      - name: "Radiator temperature 2"
+        class: "temperature"
+        uom: "°C"
+        scale: 1
+        rule: 2
+        registers: [ 0x041B ]
+        icon: 'mdi:thermometer'
+      - name: "Radiator temperature 3"
+        class: "temperature"
+        uom: "°C"
+        scale: 1
+        rule: 2
+        registers: [ 0x041C ]
+        icon: 'mdi:thermometer'
+      - name: "Radiator temperature 4"
+        class: "temperature"
+        uom: "°C"
+        scale: 1
+        rule: 2
+        registers: [ 0x041D ]
+        icon: 'mdi:thermometer'
+      - name: "Radiator temperature 5"
+        class: "temperature"
+        uom: "°C"
+        scale: 1
+        rule: 2
+        registers: [ 0x041E ]
+        icon: 'mdi:thermometer'
+      - name: "Radiator temperature 6"
+        class: "temperature"
+        uom: "°C"
+        scale: 1
+        rule: 2
+        registers: [ 0x041F ]
         icon: 'mdi:thermometer'
       - name: "Module temperature 1"
         class: "temperature"
@@ -70,8 +114,39 @@ parameters:
         rule: 2
         registers: [ 0x0420 ]
         icon: 'mdi:thermometer'
+      - name: "Module temperature 2"
+        class: "temperature"
+        uom: "°C"
+        scale: 1
+        rule: 2
+        registers: [ 0x0421 ]
+        icon: 'mdi:thermometer'
+      - name: "Module temperature 3"
+        class: "temperature"
+        uom: "°C"
+        scale: 1
+        rule: 2
+        registers: [ 0x0422 ]
+        icon: 'mdi:thermometer'
+
   - group: InverterDC
     items:
+      - name: "PV1 Voltage"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [ 0x0584 ]
+        icon: 'mdi:solar-power'
+      - name: "PV1 Current"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.01
+        rule: 1
+        registers: [ 0x0585 ]
+        icon: 'mdi:solar-power'
       - name: "PV1 Power"
         class: "power"
         state_class: "measurement"
@@ -80,7 +155,22 @@ parameters:
         rule: 1
         registers: [ 0x0586 ]
         icon: 'mdi:solar-power'
-
+      - name: "PV2 Voltage"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [ 0x0587 ]
+        icon: 'mdi:solar-power'
+      - name: "PV2 Current"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.01
+        rule: 1
+        registers: [ 0x0588 ]
+        icon: 'mdi:solar-power'
       - name: "PV2 Power"
         class: "power"
         state_class: "measurement"
@@ -90,80 +180,9 @@ parameters:
         registers: [ 0x0589 ]
         icon: 'mdi:solar-power'
 
-      - name: "PV1 Voltage"
-        class: "voltage"
-        state_class: "measurement"
-        uom: "V"
-        scale: 0.1
-        rule: 1
-        registers: [ 0x0584 ]
-        icon: 'mdi:solar-power'
-
-      - name: "PV2 Voltage"
-        class: "voltage"
-        state_class: "measurement"
-        uom: "V"
-        scale: 0.1
-        rule: 1
-        registers: [ 0x0587 ]
-        icon: 'mdi:solar-power'
-
-      - name: "PV1 Current"
-        class: "current"
-        state_class: "measurement"
-        uom: "A"
-        scale: 0.01
-        rule: 1
-        registers: [ 0x0585 ]
-        icon: 'mdi:solar-power'
-
-      - name: "PV2 Current"
-        class: "current"
-        state_class: "measurement"
-        uom: "A"
-        scale: 0.01
-        rule: 1
-        registers: [ 0x0588 ]
-        icon: 'mdi:solar-power'
   - group: Battery
     items:
-      - name: "Battery Power"
-        class: "power"
-        state_class: "measurement"
-        uom: "W"
-        scale: 10
-        rule: 2
-        registers: [ 0x0606 ]
-        icon: 'mdi:battery-charging'
-
-      - name: "Battery SOC"
-        class: "battery"
-        state_class: "measurement"
-        uom: "%"
-        scale: 1
-        rule: 1
-        registers: [ 0x0608 ]
-        icon: 'mdi:battery'
-
-      - name: "Battery SOH"
-        class: "battery"
-        state_class: "measurement"
-        uom: "%"
-        scale: 1
-        rule: 1
-        registers: [ 0x0609 ]
-        icon: 'mdi:battery'
-
-      - name: "Battery Current"
-        class: "current"
-        state_class: "measurement"
-        uom: "A"
-        scale: 0.01
-        rule: 2
-        registers: [ 0x0605 ]
-        icon: 'mdi:current-dc'
-
-      - name: "Battery Voltage"
+      - name: "Battery 1 Voltage"
         class: "voltage"
         state_class: "measurement"
         uom: "V"
@@ -171,8 +190,23 @@ parameters:
         rule: 1
         registers: [ 0x0604 ]
         icon: 'mdi:battery'
-
-      - name: "Battery Temperature"
+      - name: "Battery 1 Current"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.01
+        rule: 2
+        registers: [ 0x0605 ]
+        icon: 'mdi:current-dc'
+      - name: "Battery 1 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 10
+        rule: 2
+        registers: [ 0x0606 ]
+        icon: 'mdi:battery-charging'
+      - name: "Battery 1 Temperature"
         class: "temperature"
         state_class: "measurement"
         uom: "°C"
@@ -180,7 +214,23 @@ parameters:
         rule: 2
         registers: [ 0x0607 ]
         icon: 'mdi:battery'
-      - name: "Battery Number of Cycles"
+      - name: "Battery 1 SOC"
+        class: "battery"
+        state_class: "measurement"
+        uom: "%"
+        scale: 1
+        rule: 1
+        registers: [ 0x0608 ]
+        icon: 'mdi:battery'
+      - name: "Battery 1 SOH"
+        class: "battery"
+        state_class: "measurement"
+        uom: "%"
+        scale: 1
+        rule: 1
+        registers: [ 0x0609 ]
+        icon: 'mdi:battery'
+      - name: "Battery 1 Number of Cycles"
         class: ""
         state_class: "measurement"
         uom: "cycle"
@@ -188,7 +238,64 @@ parameters:
         rule: 1
         registers: [ 0x060A ]
         icon: 'mdi:battery'
-  - group: Grid
+      - name: "Battery 2 Voltage"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [ 0x060B ]
+        icon: 'mdi:battery'
+      - name: "Battery 2 Current"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.01
+        rule: 2
+        registers: [ 0x060C ]
+        icon: 'mdi:current-dc'
+      - name: "Battery 2 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 10
+        rule: 2
+        registers: [ 0x060D ]
+        icon: 'mdi:battery-charging'
+      - name: "Battery 2 Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 1
+        rule: 2
+        registers: [ 0x060E ]
+        icon: 'mdi:battery'
+      - name: "Battery 2 SOC"
+        class: "battery"
+        state_class: "measurement"
+        uom: "%"
+        scale: 1
+        rule: 1
+        registers: [ 0x060F ]
+        icon: 'mdi:battery'
+      - name: "Battery 2 SOH"
+        class: "battery"
+        state_class: "measurement"
+        uom: "%"
+        scale: 1
+        rule: 1
+        registers: [ 0x0610 ]
+        icon: 'mdi:battery'
+      - name: "Battery 2 Number of Cycles"
+        class: ""
+        state_class: "measurement"
+        uom: "cycle"
+        scale: 1
+        rule: 1
+        registers: [ 0x0611 ]
+        icon: 'mdi:battery'
+
+  - group: GridAC
     items:
       - name: "Grid Frequency"
         class: "current"
@@ -214,14 +321,14 @@ parameters:
         rule: 2
         registers: [ 0x0486 ]
         icon: 'mdi:home-lightning-bolt'
-#      - name: "ApparentPower_Output_Total"
-#        class: "power"
-#        state_class: "measurement"
-#        uom: "W"
-#        scale: 10
-#        rule: 2
-#        registers: [ 0x0487 ]
-#        icon: 'mdi:home-lightning-bolt'
+      - name: "ApparentPower_Output_Total"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 10
+        rule: 2
+        registers: [ 0x0487 ]
+        icon: 'mdi:home-lightning-bolt'
       - name: "ActivePower_PCC_Total"
         class: "power"
         state_class: "measurement"
@@ -230,22 +337,22 @@ parameters:
         rule: 2
         registers: [ 0x0488 ]
         icon: 'mdi:home-lightning-bolt'
-#      - name: "ReactivePower_PCC_Total"
-#        class: "power"
-#        state_class: "measurement"
-#        uom: "W"
-#        scale: 10
-#        rule: 2
-#        registers: [ 0x0489 ]
-#        icon: 'mdi:home-lightning-bolt'
-#      - name: "ApparentPower_PCC_Total"
-#        class: "power"
-#        state_class: "measurement"
-#        uom: "W"
-#        scale: 10
-#        rule: 2
-#        registers: [ 0x048A ]
-#        icon: 'mdi:home-lightning-bolt'
+      - name: "ReactivePower_PCC_Total"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 10
+        rule: 2
+        registers: [ 0x0489 ]
+        icon: 'mdi:home-lightning-bolt'
+      - name: "ApparentPower_PCC_Total"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 10
+        rule: 2
+        registers: [ 0x048A ]
+        icon: 'mdi:home-lightning-bolt'
       - name: "Voltage_Phase_R"
         class: "voltage"
         state_class: "measurement"
@@ -270,22 +377,22 @@ parameters:
         rule: 2
         registers: [ 0x048F ]
         icon: 'mdi:lightning-bolt-outline'
-#      - name: "ReactivePower_Output_R"
-#        class: "power"
-#        state_class: "measurement"
-#        uom: "W"
-#        scale: 10
-#        rule: 2
-#        registers: [ 0x0490 ]
-#        icon: 'mdi:lightning-bolt-outline'
-#      - name: "PowerFactor_Output_R"
-#        class: "powerfactor"
-#        state_class: "measurement"
-#        uom: "p.u."
-#        scale: 0.001
-#        rule: 2
-#        registers: [ 0x0491 ]
-#        icon: 'mdi:lightning-bolt-outline'
+      - name: "ReactivePower_Output_R"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 10
+        rule: 2
+        registers: [ 0x0490 ]
+        icon: 'mdi:lightning-bolt-outline'
+      - name: "PowerFactor_Output_R"
+        class: "powerfactor"
+        state_class: "measurement"
+        uom: "p.u."
+        scale: 0.001
+        rule: 2
+        registers: [ 0x0491 ]
+        icon: 'mdi:lightning-bolt-outline'
       - name: "Current_PCC_R"
         class: "current"
         state_class: "measurement"
@@ -294,30 +401,30 @@ parameters:
         rule: 1
         registers: [ 0x0492 ]
         icon: 'mdi:lightning-bolt-outline'
-#      - name: "ActivePower_PCC_R"
-#        class: "power"
-#        state_class: "measurement"
-#        uom: "W"
-#        scale: 10
-#        rule: 2
-#        registers: [ 0x0493 ]
-#        icon: 'mdi:lightning-bolt-outline'
-#      - name: "ReactivePower_PCC_R"
-#        class: "power"
-#        state_class: "measurement"
-#        uom: "W"
-#        scale: 10
-#        rule: 2
-#        registers: [ 0x0494 ]
-#        icon: 'mdi:lightning-bolt-outline'
-#      - name: "PowerFactor_PCC_R"
-#        class: "powerfactor"
-#        state_class: "measurement"
-#        uom: "p.u."
-#        scale: 0.001
-#        rule: 2
-#        registers: [ 0x0495 ]
-#        icon: 'mdi:lightning-bolt-outline'
+      - name: "ActivePower_PCC_R"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 10
+        rule: 2
+        registers: [ 0x0493 ]
+        icon: 'mdi:lightning-bolt-outline'
+      - name: "ReactivePower_PCC_R"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 10
+        rule: 2
+        registers: [ 0x0494 ]
+        icon: 'mdi:lightning-bolt-outline'
+      - name: "PowerFactor_PCC_R"
+        class: "powerfactor"
+        state_class: "measurement"
+        uom: "p.u."
+        scale: 0.001
+        rule: 2
+        registers: [ 0x0495 ]
+        icon: 'mdi:lightning-bolt-outline'
       - name: "Voltage_Phase_S"
         class: "voltage"
         state_class: "measurement"
@@ -342,22 +449,22 @@ parameters:
         rule: 2
         registers: [ 0x049A ]
         icon: 'mdi:lightning-bolt-outline'
-##      - name: "ReactivePower_Output_S"
-##        class: "power"
-##        state_class: "measurement"
-##        uom: "W"
-##        scale: 10
-##        rule: 2
-##        registers: [ 0x049B ]
-##        icon: 'mdi:lightning-bolt-outline'
-#      - name: "PowerFactor_Output_S"
-#        class: "powerfactor"
-#        state_class: "measurement"
-#        uom: "p.u."
-#        scale: 0.001
-#        rule: 2
-#        registers: [ 0x049C ]
-#        icon: 'mdi:lightning-bolt-outline'
+      - name: "ReactivePower_Output_S"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 10
+        rule: 2
+        registers: [ 0x049B ]
+        icon: 'mdi:lightning-bolt-outline'
+      - name: "PowerFactor_Output_S"
+        class: "powerfactor"
+        state_class: "measurement"
+        uom: "p.u."
+        scale: 0.001
+        rule: 2
+        registers: [ 0x049C ]
+        icon: 'mdi:lightning-bolt-outline'
       - name: "Current_PCC_S"
         class: "current"
         state_class: "measurement"
@@ -366,30 +473,30 @@ parameters:
         rule: 1
         registers: [ 0x049D ]
         icon: 'mdi:lightning-bolt-outline'
-#      - name: "ActivePower_PCC_S"
-#        class: "power"
-#        state_class: "measurement"
-#        uom: "W"
-#        scale: 10
-#        rule: 2
-#        registers: [ 0x049E ]
-#        icon: 'mdi:lightning-bolt-outline'
-#      - name: "ReactivePower_PCC_S"
-#        class: "power"
-#        state_class: "measurement"
-#        uom: "W"
-#        scale: 10
-#        rule: 2
-#        registers: [ 0x049F ]
-#        icon: 'mdi:lightning-bolt-outline'
-#      - name: "PowerFactor_PCC_S"
-#        class: "powerfactor"
-#        state_class: "measurement"
-#        uom: "p.u."
-#        scale: 0.001
-#        rule: 2
-#        registers: [ 0x04A0 ]
-#        icon: 'mdi:lightning-bolt-outline'
+      - name: "ActivePower_PCC_S"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 10
+        rule: 2
+        registers: [ 0x049E ]
+        icon: 'mdi:lightning-bolt-outline'
+      - name: "ReactivePower_PCC_S"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 10
+        rule: 2
+        registers: [ 0x049F ]
+        icon: 'mdi:lightning-bolt-outline'
+      - name: "PowerFactor_PCC_S"
+        class: "powerfactor"
+        state_class: "measurement"
+        uom: "p.u."
+        scale: 0.001
+        rule: 2
+        registers: [ 0x04A0 ]
+        icon: 'mdi:lightning-bolt-outline'
       - name: "Voltage_Phase_T"
         class: "voltage"
         state_class: "measurement"
@@ -414,22 +521,22 @@ parameters:
         rule: 2
         registers: [ 0x04A5 ]
         icon: 'mdi:lightning-bolt-outline'
-#      - name: "ReactivePower_Output_T"
-#        class: "power"
-#        state_class: "measurement"
-#        uom: "W"
-#        scale: 10
-#        rule: 2
-#        registers: [ 0x04A6 ]
-#        icon: 'mdi:lightning-bolt-outline'
-#      - name: "PowerFactor_Output_T"
-#        class: "powerfactor"
-#        state_class: "measurement"
-#        uom: "p.u."
-#        scale: 0.001
-#        rule: 2
-#        registers: [ 0x04A7 ]
-#        icon: 'mdi:lightning-bolt-outline'
+      - name: "ReactivePower_Output_T"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 10
+        rule: 2
+        registers: [ 0x04A6 ]
+        icon: 'mdi:lightning-bolt-outline'
+      - name: "PowerFactor_Output_T"
+        class: "powerfactor"
+        state_class: "measurement"
+        uom: "p.u."
+        scale: 0.001
+        rule: 2
+        registers: [ 0x04A7 ]
+        icon: 'mdi:lightning-bolt-outline'
       - name: "Current_PCC_T"
         class: "current"
         state_class: "measurement"
@@ -438,38 +545,38 @@ parameters:
         rule: 1
         registers: [ 0x04A8 ]
         icon: 'mdi:lightning-bolt-outline'
-#      - name: "ActivePower_PCC_T"
-#        class: "power"
-#        state_class: "measurement"
-#        uom: "W"
-#        scale: 10
-#        rule: 2
-#        registers: [ 0x04A9 ]
-#        icon: 'mdi:lightning-bolt-outline'
-#      - name: "ReactivePower_PCC_T"
-#        class: "power"
-#        state_class: "measurement"
-#        uom: "W"
-#        scale: 10
-#        rule: 2
-#        registers: [ 0x04AA ]
-#        icon: 'mdi:lightning-bolt-outline'
-#      - name: "PowerFactor_PCC_T"
-#        class: "powerfactor"
-#        state_class: "measurement"
-#        uom: "p.u."
-#        scale: 0.001
-#        rule: 2
-#        registers: [ 0x04AB ]
-#        icon: 'mdi:lightning-bolt-outline'
-#      - name: "ActivePower_PV_Ext"
-#        class: "power"
-#        state_class: "measurement"
-#        uom: "W"
-#        scale: 10
-#        rule: 1
-#        registers: [ 0x04AE ]
-#        icon: 'mdi:lightning-bolt-outline'
+      - name: "ActivePower_PCC_T"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 10
+        rule: 2
+        registers: [ 0x04A9 ]
+        icon: 'mdi:lightning-bolt-outline'
+      - name: "ReactivePower_PCC_T"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 10
+        rule: 2
+        registers: [ 0x04AA ]
+        icon: 'mdi:lightning-bolt-outline'
+      - name: "PowerFactor_PCC_T"
+        class: "powerfactor"
+        state_class: "measurement"
+        uom: "p.u."
+        scale: 0.001
+        rule: 2
+        registers: [ 0x04AB ]
+        icon: 'mdi:lightning-bolt-outline'
+      - name: "ActivePower_PV_Ext"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 10
+        rule: 1
+        registers: [ 0x04AE ]
+        icon: 'mdi:lightning-bolt-outline'
       - name: "ActivePower_Load_Sys"
         class: "power"
         state_class: "measurement"
@@ -478,9 +585,189 @@ parameters:
         rule: 2
         registers: [ 0x04AF ]
         icon: 'mdi:lightning-bolt-outline'
+
+  - group: GridEPS
+    items:
+      - name: "ActivePower_Load_Total_EPS"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 10
+        rule: 2
+        registers: [ 0x0504 ]
+        icon: 'mdi:home-lightning-bolt'
+      - name: "ReactivePower_Load_Total_EPS"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 10
+        rule: 2
+        registers: [ 0x0505 ]
+        icon: 'mdi:home-lightning-bolt'
+      - name: "ApparentPower_Load_Total_EPS"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 10
+        rule: 2
+        registers: [ 0x0506 ]
+        icon: 'mdi:home-lightning-bolt'
+      - name: "Frequency_Output_EPS"
+        class: "current"
+        state_class: "measurement"
+        uom: "Hz"
+        scale: 0.01
+        rule: 1
+        registers: [ 0x0507 ]
+        icon: 'mdi:home-lightning-bolt'
+      - name: "Voltage_Output_R_EPS"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [ 0x050A ]
+        icon: 'mdi:lightning-bolt-outline'
+      - name: "Current_Load_R_EPS"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.01
+        rule: 1
+        registers: [ 0x050B ]
+        icon: 'mdi:lightning-bolt-outline'
+      - name: "ActivePower_Load_R_EPS"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 10
+        rule: 2
+        registers: [ 0x050C ]
+        icon: 'mdi:lightning-bolt-outline'
+      - name: "ReactivePower_Load_R_EPS"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 10
+        rule: 2
+        registers: [ 0x050D ]
+        icon: 'mdi:lightning-bolt-outline'
+      - name: "ApparentPower_Load_R_EPS"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 10
+        rule: 2
+        registers: [ 0x050E ]
+        icon: 'mdi:home-lightning-bolt'
+      - name: "LoadPeakRatio_R_EPS"
+        class: "powerfactor"
+        state_class: "measurement"
+        uom: "p.u."
+        scale: 0.01
+        rule: 2
+        registers: [ 0x050F ]
+        icon: 'mdi:lightning-bolt-outline'  
+      - name: "Voltage_Output_S_EPS"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [ 0x0512 ]
+        icon: 'mdi:lightning-bolt-outline'
+      - name: "Current_Load_S_EPS"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.01
+        rule: 1
+        registers: [ 0x0513 ]
+        icon: 'mdi:lightning-bolt-outline'
+      - name: "ActivePower_Load_S_EPS"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 10
+        rule: 2
+        registers: [ 0x0514 ]
+        icon: 'mdi:lightning-bolt-outline'
+      - name: "ReactivePower_Load_S_EPS"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 10
+        rule: 2
+        registers: [ 0x0515 ]
+        icon: 'mdi:lightning-bolt-outline'
+      - name: "ApparentPower_Load_S_EPS"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 10
+        rule: 2
+        registers: [ 0x0516 ]
+        icon: 'mdi:home-lightning-bolt'
+      - name: "LoadPeakRatio_S_EPS"
+        class: "powerfactor"
+        state_class: "measurement"
+        uom: "p.u."
+        scale: 0.01
+        rule: 2
+        registers: [ 0x0517 ]
+        icon: 'mdi:lightning-bolt-outline'
+      - name: "Voltage_Output_T_EPS"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [ 0x051A ]
+        icon: 'mdi:lightning-bolt-outline'
+      - name: "Current_Load_T_EPS"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.01
+        rule: 1
+        registers: [ 0x051B ]
+        icon: 'mdi:lightning-bolt-outline'
+      - name: "ActivePower_Load_T_EPS"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 10
+        rule: 2
+        registers: [ 0x051C ]
+        icon: 'mdi:lightning-bolt-outline'
+      - name: "ReactivePower_Load_T_EPS"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 10
+        rule: 2
+        registers: [ 0x051D ]
+        icon: 'mdi:lightning-bolt-outline'
+      - name: "ApparentPower_Load_T_EPS"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 10
+        rule: 2
+        registers: [ 0x051E ]
+        icon: 'mdi:home-lightning-bolt'
+      - name: "LoadPeakRatio_T_EPS"
+        class: "powerfactor"
+        state_class: "measurement"
+        uom: "p.u."
+        scale: 0.01
+        rule: 2
+        registers: [ 0x051F ]
+        icon: 'mdi:lightning-bolt-outline'
+
   - group: Generation
     items:
-      - name: "PV Generation today"
+      - name: "Daily PV Generation"
         class: "energy"
         state_class: "total_increasing"
         uom: "kWh"
@@ -488,7 +775,7 @@ parameters:
         rule: 3
         registers: [ 0x0685,0x0684 ]
         icon: 'mdi:solar-power'
-      - name: "PV generation total"
+      - name: "Total PV Generation"
         class: "energy"
         state_class: "total_increasing"
         uom: "kWh"
@@ -496,7 +783,7 @@ parameters:
         rule: 3
         registers: [ 0x0687,0x0686 ]
         icon: 'mdi:solar-power'
-      - name: "Load consumption today"
+      - name: "Daily Load Consumption"
         class: "energy"
         state_class: "total_increasing"
         uom: "kWh"
@@ -504,7 +791,7 @@ parameters:
         rule: 3
         registers: [ 0x0689,0x0688 ]
         icon: 'mdi:lightning-bolt-outline'
-      - name: "Load consumption total"
+      - name: "Total Load Consumption"
         class: "energy"
         state_class: "total_increasing"
         uom: "kWh"
@@ -512,7 +799,6 @@ parameters:
         rule: 3
         registers: [ 0x068B,0x068A ]
         icon: 'mdi:solar-power'
-
       - name: "Daily Energy Bought"
         class: "energy"
         state_class: "total_increasing"
@@ -521,7 +807,6 @@ parameters:
         rule: 3
         registers: [ 0x068D,0x068C ]
         icon: 'mdi:transmission-tower-export'
-
       - name: "Total Energy Bought"
         class: "energy"
         state_class: "total_increasing"
@@ -530,7 +815,6 @@ parameters:
         rule: 3
         registers: [ 0x068F,0x068E ]
         icon: 'mdi:transmission-tower-export'
-
       - name: "Daily Energy Sold"
         class: "energy"
         state_class: "total_increasing"
@@ -539,7 +823,6 @@ parameters:
         rule: 3
         registers: [ 0x0691,0x0690 ]
         icon: 'mdi:transmission-tower-import'
-
       - name: "Total Energy Sold"
         class: "energy"
         state_class: "total_increasing"
@@ -548,7 +831,6 @@ parameters:
         rule: 3
         registers: [ 0x0693,0x0692 ]
         icon: 'mdi:transmission-tower-import'
-
       - name: "Daily Battery Charge"
         class: "energy"
         state_class: "total_increasing"
@@ -581,6 +863,7 @@ parameters:
         rule: 3
         registers: [ 0x069b,0x069A ]
         icon: 'mdi:battery-minus'
+
   - group: Alert
     items:
       - name: "Alert"


### PR DESCRIPTION
I have reviewed the registry values from the file that ZCS shared and have removed comments from sensors that were removed.
I've added translations for Italian language and edited the documentation to better identify rebranded 3-phase Sofar inverters.

This is the file ZCS shared: [ModBus-RTU.Communication.Protocol.3PH.Hybrid.and.Inverter.pdf](https://github.com/StephanJoubert/home_assistant_solarman/files/10862339/ModBus-RTU.Communication.Protocol.3PH.Hybrid.and.Inverter.pdf)
