### PR TITLE
Update definition for Deye 2 MPPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,12 @@ sensor:
 ### Lookup Files
 
 | Lookup File             | Inverters supported                      | Notes                                                        |
-| ----------------------- | ---------------------------------------- | ------------------------------------------------------------ |
+|-------------------------|------------------------------------------|--------------------------------------------------------------|
 | deye_hybrid.yaml        | DEYE/Sunsynk/SolArk Hybrid inverters     | used when no lookup specified                                |
 | deye_sg04lp3.yaml       | DEYE/Sunsynk/SolArk Hybrid 8/12K-SG04LP3 | e.g. 12K-SG04LP3-EU                                          |
 | deye_string.yaml        | DEYE/Sunsynk/SolArk String inverters     | e.g. SUN-4/5/6/7/8/10/12K-G03 Plus                           |
-| deye_4mppt.yaml         | DEYE Microinverter                       |
+| deye_2mppt.yaml         | DEYE Microinverter with 2 MPPT Trackers  | e.g. SUN{600/800/1000}G3
+| deye_4mppt.yaml         | DEYE Microinverter with 4 MPPT Trackers  |
 | sofar_lsw3.yaml         | SOFAR Inverters                          |
 | sofar_hyd3k-6k.yaml     | SOFAR Hybrid inverter                    | HYD 6000 or rebranded, ex. ZCS Azzurro HYD-ZSS               |
 | solis_hybrid.yaml       | SOLIS Hybrid inverter                    |

--- a/custom_components/solarman/inverter_definitions/deye_2mppt.yaml
+++ b/custom_components/solarman/inverter_definitions/deye_2mppt.yaml
@@ -65,10 +65,9 @@ parameters:
       icon: 'mdi:solar-power'
       validation:
         min: 0.1
-        invalidate_all:
 
   - group: Grid
-    items: 
+    items:
     - name: "AC Voltage"
       class: "voltage"
       state_class: "measurement"
@@ -80,7 +79,7 @@ parameters:
 
     - name: "AC Output Frequency"
       class: "frequency"
-      state_class: "measurement"      
+      state_class: "measurement"
       uom: "Hz"
       scale: 0.01
       rule: 1
@@ -88,24 +87,26 @@ parameters:
       icon: 'mdi:home-lightning-bolt'
 
   - group: Inverter
-    items: 
+    items:
     - name: "Running Status"
       class: ""
-      state_class: ""      
+      state_class: ""
       uom: ""
       scale: 1
       rule: 1
       registers: [0x003B]
       isstr: true
-      lookup: 
+      lookup:
       - key: 0
         value: "Stand-by"
       - key: 1
-        value: "Self-checking"
+        value: "Self-check"
       - key: 2
         value: "Normal"
       - key: 3
-        value: "FAULT"
+        value: "Warning"
+      - key: 4
+        value: "Fault"
       icon: 'mdi:home-lightning-bolt'
 
     - name: "Total AC Output Power (Active)"
@@ -117,9 +118,18 @@ parameters:
       registers: [0x0056, 0x0057]
       icon: 'mdi:home-lightning-bolt'
 
+    - name: "Radiator Temperature"
+      class: "temperature"
+      uom: "°C"
+      state_class: "measurement"
+      scale: 0.01
+      rule: 1
+      offset: 1000
+      registers: [0x005a]
+
     - name: "Inverter ID"
       class: ""
-      state_class: ""      
+      state_class: ""
       uom: ""
       scale: 1
       rule: 5


### PR DESCRIPTION
This PR updates the definition file that is used for various deye microinverters

Here are the changes:
- Add radiator temperature to the list of parameters
- Fix running status parameter mapping
- Remove `invalidate_all` from validation as it causes the integration to not work at all in freshly deployed setups
- Add the definition yaml to the readme
- General auto-formatting by pycharm