### PR TITLE
Invalidate any cached previous readings when disconnected

### DIFF
--- a/custom_components/solarman/sensor.py
+++ b/custom_components/solarman/sensor.py
@@ -157,7 +157,7 @@ class SolarmanStatus(SolarmanSensor, Entity):
         return self.p_state
 
     def update(self):
-        self.p_state = getattr(self.inverter, self._field_name)
+        self.p_state = getattr(self.inverter, self._field_name, None)
 
 
 #############################################################################################################
@@ -186,6 +186,7 @@ class SolarmanSensorText(SolarmanStatus):
             if self._field_name in val:
                 self.p_state = val[self._field_name]
             else:
+                self.p_state = None
                 _LOGGER.debug(f'No value recorded for {self._field_name}')
 
 

--- a/custom_components/solarman/sensor.py
+++ b/custom_components/solarman/sensor.py
@@ -186,7 +186,7 @@ class SolarmanSensorText(SolarmanStatus):
             if self._field_name in val:
                 self.p_state = val[self._field_name]
             else:
-                if self.uom in ("W", "kW", "°C", "Hz", "V", "A", "VA", "%"):
+                if getattr(self, 'uom', None) in ("W", "kW", "°C", "Hz", "V", "A", "VA", "%"):
                     self.p_state = None
                 _LOGGER.debug(f'No value recorded for {self._field_name}')
 

--- a/custom_components/solarman/sensor.py
+++ b/custom_components/solarman/sensor.py
@@ -186,7 +186,8 @@ class SolarmanSensorText(SolarmanStatus):
             if self._field_name in val:
                 self.p_state = val[self._field_name]
             else:
-                self.p_state = None
+                if self.uom in ("W", "kW", "°C", "Hz", "V", "A", "VA", "%"):
+                    self.p_state = None
                 _LOGGER.debug(f'No value recorded for {self._field_name}')
 
 

--- a/custom_components/solarman/solarman.py
+++ b/custom_components/solarman/solarman.py
@@ -249,9 +249,13 @@ class Inverter:
                 self._current_val = params.get_result()
             else:
                 self.status_connection = "Disconnected"
+                # Clear cached previous results to not report stale and incorrect data
+                self._current_val = {}
         except Exception as e:
             log.warning(f"Querying inverter {self._serial} at {self._host}:{self._port} failed on connection start with exception [{type(e).__name__}]")
             self.status_connection = "Disconnected"
+            # Clear cached previous results to not report stale and incorrect data
+            self._current_val = {}
         finally:
             if sock:
                 sock.close()


### PR DESCRIPTION
With the current implementation, as soon as the sun goes down, we get these invalid states in the home assistant history:

![image](https://user-images.githubusercontent.com/974410/223478794-02d67a88-871b-4058-8881-d6acb0404bb2.png)

This is annoying and might also mess with the long-term statistics.
Therefore, this PR fixes that by clearing the cache when the inverter enters the `Disconnected` state.

With this change, the graph now correctly shows no data for the time where there was no connection to the inverter:
![image](https://user-images.githubusercontent.com/974410/223479592-2668fd57-b664-49e8-ad28-b79a5a1878fd.png)

