### PR TITLE
Add new KStar Hybrid inverter definition

### DIFF
--- a/custom_components/solarman/const.py
+++ b/custom_components/solarman/const.py
@@ -11,6 +11,7 @@ LOOKUP_FILES = [
     'deye_hybrid.yaml',
     'deye_sg04lp3.yaml',
     'deye_string.yaml',
+    'kstar_hybrid.yaml',
     'sofar_lsw3.yaml',
     'sofar_wifikit.yaml',
     'solis_hybrid.yaml',

--- a/custom_components/solarman/inverter_definitions/kstar_hybrid.yml
+++ b/custom_components/solarman/inverter_definitions/kstar_hybrid.yml
@@ -589,6 +589,9 @@ parameters:
         registers: [3208, 3209, 3210, 3211, 3212, 3213, 3214, 3215]
         icon: 'mdi:wrench'
 
+      # ARM AND DSP version numbers ("VX.Y.Z") are set in the two bytes on each register. The first byte contains the
+      # X.Y part (scale 0.1), and the second by contains the Z part. How should we transform these values from a number
+      # to a parsed string?
       - name: "ARM Version Number"
         class: ""
         state_class: "measurement"
@@ -660,7 +663,7 @@ parameters:
   # - T: Tertiary
   - group: R Phase
     items:
-      - name: "R Inverter Voltage"
+      - name: "R-phase Inverter Voltage"
         class: "voltage"
         state_class: "measurement"
         uom: "V"
@@ -669,7 +672,7 @@ parameters:
         registers: [ 3123 ]
         icon: 'mdi:home-lightning-bolt'
 
-      - name: "R Inverter Current"
+      - name: "R-phase Inverter Current"
         class: "current"
         state_class: "measurement"
         uom: "A"
@@ -678,7 +681,7 @@ parameters:
         registers: [ 3124 ]
         icon: 'mdi:home-lightning-bolt'
 
-      - name: "R Inverter Frequency"
+      - name: "R-phase Inverter Frequency"
         class: "frequency"
         state_class: "measurement"
         uom: "Hz"
@@ -687,7 +690,7 @@ parameters:
         registers: [ 3125 ]
         icon: 'mdi:home-lightning-bolt'
 
-      - name: "R Inverter Power"
+      - name: "R-phase Inverter Power"
         class: "power"
         state_class: "measurement"
         uom: "W"
@@ -696,7 +699,7 @@ parameters:
         registers: [ 3126 ]
         icon: 'mdi:home-lightning-bolt'
 
-      - name: "R Backup Voltage"
+      - name: "R-phase Backup Voltage"
         class: "voltage"
         state_class: "measurement"
         uom: "V"
@@ -705,7 +708,7 @@ parameters:
         registers: [ 3135 ]
         icon: 'mdi:home-lightning-bolt'
 
-      - name: "R Backup Current"
+      - name: "R-phase Backup Current"
         class: "current"
         state_class: "measurement"
         uom: "A"
@@ -714,7 +717,7 @@ parameters:
         registers: [ 3136 ]
         icon: 'mdi:home-lightning-bolt'
 
-      - name: "R Backup Power"
+      - name: "R-phase Backup Power"
         class: "power"
         state_class: "measurement"
         uom: "W"
@@ -723,7 +726,7 @@ parameters:
         registers: [ 3137 ]
         icon: 'mdi:home-lightning-bolt'
 
-      - name: "R Load Power"
+      - name: "R-phase Load Power"
         class: "power"
         state_class: "measurement"
         uom: "W"

--- a/custom_components/solarman/inverter_definitions/kstar_hybrid.yml
+++ b/custom_components/solarman/inverter_definitions/kstar_hybrid.yml
@@ -199,9 +199,19 @@ parameters:
         registers: [ 3122, 3121 ]
         icon: 'mdi:transmission-tower-export'
 
+      # Should this be the sum of the 3 phases "Meter Power"?
+      - name: "Total Grid Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [ 3100 ]
+        icon: 'mdi:home-lightning-bolt'
+
   - group: Electricity Consumption
     items:
-      # Should this be the sum of the 3 phases "Load Power"|"?
+      # Should this be the sum of the 3 phases "Load Power"?
       - name: "Total Consumption Power"
         class: "power"
         state_class: "measurement"

--- a/custom_components/solarman/inverter_definitions/kstar_hybrid.yml
+++ b/custom_components/solarman/inverter_definitions/kstar_hybrid.yml
@@ -673,6 +673,42 @@ parameters:
   # - T: Tertiary
   - group: R Phase
     items:
+      - name: "R-phase Grid Voltage"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [ 3097 ]
+        icon: 'mdi:home-lightning-bolt'
+
+      - name: "R-phase Grid Frequency"
+        class: "frequency"
+        state_class: "measurement"
+        uom: "Hz"
+        scale: 0.01
+        rule: 1
+        registers: [ 3098 ]
+        icon: 'mdi:home-lightning-bolt'
+
+      - name: "R-phase Meter Current"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.001
+        rule: 2
+        registers: [ 3099 ]
+        icon: 'mdi:home-lightning-bolt'
+
+      - name: "R-phase Grid Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [ 3100 ]
+        icon: 'mdi:home-lightning-bolt'
+
       - name: "R-phase Inverter Voltage"
         class: "voltage"
         state_class: "measurement"

--- a/custom_components/solarman/inverter_definitions/kstar_hybrid.yml
+++ b/custom_components/solarman/inverter_definitions/kstar_hybrid.yml
@@ -201,6 +201,16 @@ parameters:
 
   - group: Electricity Consumption
     items:
+      # Should this be the sum of the 3 phases "Load Power"|"?
+      - name: "Total Consumption Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [ 3144 ]
+        icon: 'mdi:home-lightning-bolt'
+
       - name: "Daily Consumption"
         class: "energy"
         state_class: "total_increasing"

--- a/custom_components/solarman/inverter_definitions/kstar_hybrid.yml
+++ b/custom_components/solarman/inverter_definitions/kstar_hybrid.yml
@@ -113,16 +113,16 @@ parameters:
         uom: "kWh"
         scale: 1
         rule: 3
-        registers: [ 3040,3039 ]
+        registers: [ 3040, 3039 ]
         icon: 'mdi:solar-power'
 
       - name: "Cumulative Production"
         class: "energy"
-        state_class: "total_increasing"
+        state_class: "total"
         uom: "kWh"
         scale: 0.1
         rule: 3
-        registers: [ 3042,3041 ]
+        registers: [ 3042, 3041 ]
         icon: 'mdi:solar-power'
 
   - group: Power Grid
@@ -156,7 +156,7 @@ parameters:
 
       - name: "Cumulative Energy Purchased"
         class: "energy"
-        state_class: "total_increasing"
+        state_class: "total"
         uom: "kWh"
         scale: 0.1
         rule: 3
@@ -170,7 +170,7 @@ parameters:
         scale: 0.1
         rule: 1
         registers: [ 3116 ]
-        icon: 'mdi:transmission-tower-import'
+        icon: 'mdi:transmission-tower-export'
 
       - name: "Monthly Energy Feed-In"
         class: "energy"
@@ -179,7 +179,7 @@ parameters:
         scale: 1
         rule: 3
         registers: [ 3118, 3117 ]
-        icon: 'mdi:transmission-tower-import'
+        icon: 'mdi:transmission-tower-export'
 
       - name: "Yearly Energy Feed-In"
         class: "energy"
@@ -188,11 +188,11 @@ parameters:
         scale: 1
         rule: 3
         registers: [ 3120, 3119 ]
-        icon: 'mdi:transmission-tower-import'
+        icon: 'mdi:transmission-tower-export'
 
       - name: "Cumulative Grid Feed-In"
         class: "energy"
-        state_class: "total_increasing"
+        state_class: "total"
         uom: "kWh"
         scale: 0.1
         rule: 3
@@ -214,7 +214,7 @@ parameters:
         class: "energy"
         state_class: "total_increasing"
         uom: "kWh"
-        scale: 0.1
+        scale: 1
         rule: 3
         registers: [ 3149, 3148 ]
         icon: 'mdi:home-lightning-bolt'
@@ -223,14 +223,14 @@ parameters:
         class: "energy"
         state_class: "total_increasing"
         uom: "kWh"
-        scale: 0.1
+        scale: 1
         rule: 3
         registers: [ 3151, 3150 ]
         icon: 'mdi:home-lightning-bolt'
 
       - name: "Cumulative Consumption"
         class: "energy"
-        state_class: "total_increasing"
+        state_class: "total"
         uom: "kWh"
         scale: 0.1
         rule: 3
@@ -418,7 +418,7 @@ parameters:
         - key: 32
           value: "E10KT"
         - key: 33
-          value: "BE8KT"
+          value: "E8KT"
         - key: 34
           value: "E12KT"
         icon: 'mdi:wrench'
@@ -691,7 +691,7 @@ parameters:
         class: "power"
         state_class: "measurement"
         uom: "W"
-        scale: 0.1
+        scale: 1
         rule: 2
         registers: [ 3126 ]
         icon: 'mdi:home-lightning-bolt'
@@ -709,7 +709,7 @@ parameters:
         class: "current"
         state_class: "measurement"
         uom: "A"
-        scale: 0.1
+        scale: 0.01
         rule: 1
         registers: [ 3136 ]
         icon: 'mdi:home-lightning-bolt'
@@ -718,7 +718,7 @@ parameters:
         class: "power"
         state_class: "measurement"
         uom: "W"
-        scale: 0.1
+        scale: 1
         rule: 1
         registers: [ 3137 ]
         icon: 'mdi:home-lightning-bolt'

--- a/custom_components/solarman/inverter_definitions/kstar_hybrid.yml
+++ b/custom_components/solarman/inverter_definitions/kstar_hybrid.yml
@@ -1,0 +1,734 @@
+# KSTAR Hybrid Inverter
+# Modbus information taken from "MODBUS RS485 Communication Protocol V2.5" document provided by KSTAR
+
+#INPUT_REGISTERS = 3000 - 3660    # 0x0BB8 - 0x0E4C
+#HOLDING_REGISTERS = 3200 - 3237  # 0x0C80 - 0x0C9B
+
+requests:
+  # Input registers 3000 - 3667
+  - start: 3000
+    end: 3125
+    mb_functioncode: 0x04
+
+  # Input registers 3200 - 3228 not read as they would clash with holding registers
+  - start: 3125
+    end: 3200
+    mb_functioncode: 0x04
+
+  - start: 3228
+    end: 3250
+    mb_functioncode: 0x04
+
+  - start: 3250
+    end: 3375
+    mb_functioncode: 0x04
+
+  - start: 3375
+    end: 3500
+    mb_functioncode: 0x04
+
+  # Holding registers 3200 - 3237. Inverter system information.
+  - start: 3200
+    end: 3218
+    mb_functioncode: 0x03
+
+parameters:
+  - group: solar
+    items:
+      - name: "PV1 Voltage"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [ 3000 ]
+        icon: 'mdi:solar-power'
+
+      - name: "PV2 Voltage"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [ 3001 ]
+        icon: 'mdi:solar-power'
+
+      - name: "PV1 Current"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.01
+        rule: 2
+        registers: [ 3012 ]
+        icon: 'mdi:solar-power'
+
+      - name: "PV2 Current"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.01
+        rule: 2
+        registers: [ 3013 ]
+        icon: 'mdi:solar-power'
+
+      - name: "PV1 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [ 3024 ]
+        icon: 'mdi:solar-power'
+
+      - name: "PV2 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [ 3025 ]
+        icon: 'mdi:solar-power'
+
+      - name: "Daily Production"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 1
+        registers: [ 3036 ]
+        icon: 'mdi:solar-power'
+
+      - name: "Monthly Production"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 1
+        rule: 3
+        registers: [ 3038, 3037 ]
+        icon: 'mdi:solar-power'
+
+      - name: "Yearly Production"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 1
+        rule: 3
+        registers: [ 3040,3039 ]
+        icon: 'mdi:solar-power'
+
+      - name: "Cumulative Production"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 3
+        registers: [ 3042,3041 ]
+        icon: 'mdi:solar-power'
+
+  - group: Power Grid
+    items:
+      - name: "Daily Energy Purchased"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 1
+        registers: [ 3109 ]
+        icon: 'mdi:transmission-tower-import'
+
+      - name: "Monthly Energy Purchased"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 1
+        rule: 3
+        registers: [ 3111, 3110 ]
+        icon: 'mdi:transmission-tower-import'
+
+      - name: "Yearly Energy Purchased"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 1
+        rule: 3
+        registers: [ 3113, 3112 ]
+        icon: 'mdi:transmission-tower-import'
+
+      - name: "Cumulative Energy Purchased"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 3
+        registers: [ 3115, 3114 ]
+        icon: 'mdi:transmission-tower-import'
+
+      - name: "Daily Energy Feed-In"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 1
+        registers: [ 3116 ]
+        icon: 'mdi:transmission-tower-import'
+
+      - name: "Monthly Energy Feed-In"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 1
+        rule: 3
+        registers: [ 3118, 3117 ]
+        icon: 'mdi:transmission-tower-import'
+
+      - name: "Yearly Energy Feed-In"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 1
+        rule: 3
+        registers: [ 3120, 3119 ]
+        icon: 'mdi:transmission-tower-import'
+
+      - name: "Cumulative Grid Feed-In"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 3
+        registers: [ 3122, 3121 ]
+        icon: 'mdi:transmission-tower-export'
+
+  - group: Electricity Consumption
+    items:
+      - name: "Daily Consumption"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 1
+        registers: [ 3147 ]
+        icon: 'mdi:home-lightning-bolt'
+
+      - name: "Monthly Consumption"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 3
+        registers: [ 3149, 3148 ]
+        icon: 'mdi:home-lightning-bolt'
+
+      - name: "Yearly Consumption"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 3
+        registers: [ 3151, 3150 ]
+        icon: 'mdi:home-lightning-bolt'
+
+      - name: "Cumulative Consumption"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 3
+        registers: [ 3153, 3152 ]
+        icon: 'mdi:home-lightning-bolt'
+
+  - group: Battery
+    items:
+      - name: "Battery Type"
+        class: "battery"
+        state_class: "measurement"
+        uom: ''
+        scale: 1
+        rule: 1
+        registers: [ 3062 ]
+        icon: 'mdi:battery'
+        lookup:
+        - key: 1
+          value: "Lead-Acid"
+        - key: 6
+          value: "LFP"
+
+      - name: "Battery Voltage"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.01
+        rule: 1
+        registers: [ 3063 ]
+        icon: 'mdi:battery-charging'
+
+      - name: "Battery Current"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.1
+        rule: 2
+        registers: [ 3064 ]
+        icon: 'mdi:battery-charging-10'
+
+      - name: "Battery Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [ 3065 ]
+        icon: 'mdi:battery-charging-high'
+
+      - name: "Battery SoC"
+        class: "battery"
+        state_class: "measurement"
+        uom: "%"
+        scale: 0.1
+        rule: 1
+        registers: [ 3066 ]
+        icon: 'mdi:battery'
+
+      - name: "Battery Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 2
+        registers: [ 3067 ]
+        icon: 'mdi:battery-heart-outline'
+
+      - name: "Battery Discharge Capacity Depth"
+        class: "battery"
+        state_class: "measurement"
+        uom: "%"
+        scale: 1
+        rule: 1
+        registers: [ 3068 ]
+        icon: 'mdi:battery-20'
+        validation:
+          min: 10
+          max: 95
+
+      - name: "Battery Radiator Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 2
+        registers: [ 3056 ]
+        icon: 'mdi:battery-heart-outline'
+
+      - name: "Battery Total Discharge"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 1
+        rule: 3
+        registers: [ 3293, 3292 ]
+        icon: 'mdi:battery-minus-variant'
+
+      - name: "Battery Daily Discharge"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 1
+        registers: [ 3294 ]
+        icon: 'mdi:battery-minus-variant'
+
+      - name: "Battery Total Charge"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 1
+        rule: 3
+        registers: [ 3300, 3299 ]
+        icon: 'mdi:battery-minus-variant'
+
+      - name: "Battery Daily Charge"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 1
+        registers: [ 3301 ]
+        icon: 'mdi:battery-plus-variant'
+
+  - group: Inverter Information
+    items:
+      - name: "Inverter Working Mode"
+        class: ""
+        state_class: "measurement"
+        uom: ""
+        scale: 1
+        rule: 1
+        registers: [3044]
+        lookup:
+        - key: 0
+          value: "Self Consumption"
+        - key: 1
+          value: "Peak Shift"
+        - key: 2
+          value: "Battery Priority"
+        icon: 'mdi:wrench'
+
+      - name: "Inverter Model"
+        class: ""
+        state_class: "measurement"
+        uom: ""
+        scale: 1
+        rule: 1
+        registers: [3045]
+        lookup:
+        # Single-phase models
+        - key: 0
+          value: "KSE-2K-048S"
+        - key: 1
+          value: "KSE-3K-048S"
+        - key: 2
+          value: "KSE-3.6K-048S"
+        - key: 3
+          value: "KSE-4.6K-048S"
+        - key: 4
+          value: "KSE-5K-048S"
+        - key: 5
+          value: "KSE-3.6K-048"
+        - key: 6
+          value: "KSE-4.6K-048"
+        - key: 7
+          value: "KSE-5K-048"
+        - key: 8
+          value: "KSE-6K-048"
+        - key: 9
+          value: "BluE-S 3680D"
+        - key: 11
+          value: "BluE-S 5000D"
+        - key: 12
+          value: "BluE-S 6000D"
+        - key: 14
+          value: "KSE-3K-048S M1"
+        - key: 15
+          value: "BluE-S 3680D M1"
+        - key: 17
+          value: "BluE-S 5000D M1"
+        - key: 18
+          value: "BluE-S 6000D M1"
+        # Three-phase models
+        - key: 32
+          value: "E10KT"
+        - key: 33
+          value: "BE8KT"
+        - key: 34
+          value: "E12KT"
+        icon: 'mdi:wrench'
+
+      - name: "System status"
+        class: ""
+        state_class: "measurement"
+        uom: ""
+        scale: 1
+        rule: 1
+        registers: [3046]
+        lookup:
+        - key: 0
+          value: "Initialize"
+        - key: 1
+          value: "Stand-by"
+        - key: 2
+          value: "Hybrid Grid"
+        - key: 3
+          value: "Off-Network"
+        - key: 4
+          value: "Mains Charging"
+        - key: 5
+          value: "PV Charging"
+        - key: 6
+          value: "Mains Bypass"
+        - key: 7
+          value: "Fault"
+        - key: 8
+          value: "Debug"
+        - key: 9
+          value: "Forced Charge"
+        - key: 10
+          value: "Power on the device separately from the"
+        - key: 11
+          value: "DSP Burn"
+        - key: 12
+          value: "MCU Burn"
+        - key: 13
+          value: "Permanent Error"
+        icon: 'mdi:wrench'
+
+      - name: "Inverter status"
+        class: ""
+        state_class: "measurement"
+        uom: ""
+        scale: 1
+        rule: 1
+        registers: [3047]
+        lookup:
+        - key: 0
+          value: "Stand-by"
+        - key: 1
+          value: "Off-Grid"
+        - key: 2
+          value: "On-Grid"
+        - key: 3
+          value: "Off-Grid to On-Grid"
+        - key: 4
+          value: "On-Grid to Off-Grid"
+        icon: 'mdi:wrench'
+
+      - name: "DCDC status"
+        class: ""
+        state_class: "measurement"
+        uom: ""
+        scale: 1
+        rule: 1
+        registers: [3048]
+        lookup:
+        - key: 0
+          value: "Stand-by"
+        - key: 1
+          value: "Soft Boot"
+        - key: 2
+          value: "Charging Mode"
+        - key: 3
+          value: "Discharging Mode"
+        icon: 'mdi:wrench'
+
+      - name: "DSP Alarm Code"
+        class: ""
+        state_class: "measurement"
+        uom: ""
+        scale: 1
+        rule: 6
+        registers: [3050, 3049]
+        icon: 'mdi:wrench'
+
+      - name: "DSP Error Code"
+        class: ""
+        state_class: "measurement"
+        uom: ""
+        scale: 1
+        rule: 6
+        registers: [3052, 3051]
+        icon: 'mdi:wrench'
+
+      - name: "Grid Standard"
+        class: ""
+        state_class: "measurement"
+        uom: ""
+        scale: 1
+        rule: 1
+        registers: [3193]
+        lookup:
+        - key: 0
+          value: "China"
+        - key: 1
+          value: "Germany"
+        - key: 2
+          value: "Australia"
+        - key: 3
+          value: "Italy"
+        - key: 4
+          value: "Spain"
+        - key: 5
+          value: "UK"
+        - key: 6
+          value: "Hungary"
+        - key: 7
+          value: "Belgium"
+        - key: 8
+          value: "West Australia"
+        - key: 9
+          value: "Greece"
+        - key: 10
+          value: "France"
+        - key: 11
+          value: "Bangkok"
+        - key: 12
+          value: "Thailand"
+        - key: 13
+          value: "South Africa"
+        - key: 14
+          value: "EN50549"
+        - key: 15
+          value: "Brazil"
+        - key: 16
+          value: "VDE0126"
+        - key: 17
+          value: "Ireland"
+        - key: 18
+          value: "Israel"
+        - key: 19
+          value: "Poland"
+        - key: 20
+          value: "Chile"
+        - key: 21
+          value: "Local"
+        icon: 'mdi:wrench'
+
+      - name: "Inverter Model Name"
+        class: ""
+        state_class: "measurement"
+        uom: ""
+        scale: 1
+        rule: 5
+        registers: [3200, 3201, 3202, 3203, 3204, 3205, 3206, 3207]
+        icon: 'mdi:wrench'
+
+      - name: "Inverter Battery Name"
+        class: ""
+        state_class: "measurement"
+        uom: ""
+        scale: 1
+        rule: 5
+        registers: [3208, 3209, 3210, 3211, 3212, 3213, 3214, 3215]
+        icon: 'mdi:wrench'
+
+      - name: "ARM Version Number"
+        class: ""
+        state_class: "measurement"
+        uom: ""
+        scale: 1
+        rule: 1
+        registers: [3216]
+        icon: 'mdi:wrench'
+
+      - name: "DSP Version Number"
+        class: ""
+        state_class: "measurement"
+        uom: ""
+        scale: 1
+        rule: 1
+        registers: [3217]
+        icon: 'mdi:wrench'
+
+      - name: "Inverter SN Number"
+        class: ""
+        state_class: "measurement"
+        uom: ""
+        scale: 1
+        rule: 5
+        registers: [3228, 3229, 3230, 3231, 3232, 3233, 3234, 3235, 3236, 3237, 3238]
+        icon: 'mdi:wrench'
+
+  - group: Inverter
+    items:
+      - name: "Inverter Bus Voltage"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [ 3053 ]
+        icon: 'mdi:home-lightning-bolt'
+
+      - name: "Inverter DC Bus Voltage"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [ 3054 ]
+        icon: 'mdi:home-lightning-bolt'
+
+      - name: "Inverter Radiator Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 2
+        registers: [ 3055 ]
+        icon: 'mdi:thermometer'
+
+      - name: "Chassis Internal Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 2
+        registers: [ 3057 ]
+        icon: 'mdi:battery-heart-outline'
+
+  # Different phases for 3-phase inverters. Only some models have 3 phases, see "Inverter Model" item
+  # - R: Referent
+  # - S: Secondary
+  # - T: Tertiary
+  - group: R Phase
+    items:
+      - name: "R Inverter Voltage"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [ 3123 ]
+        icon: 'mdi:home-lightning-bolt'
+
+      - name: "R Inverter Current"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.01
+        rule: 2
+        registers: [ 3124 ]
+        icon: 'mdi:home-lightning-bolt'
+
+      - name: "R Inverter Frequency"
+        class: "frequency"
+        state_class: "measurement"
+        uom: "Hz"
+        scale: 0.01
+        rule: 1
+        registers: [ 3125 ]
+        icon: 'mdi:home-lightning-bolt'
+
+      - name: "R Inverter Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 0.1
+        rule: 2
+        registers: [ 3126 ]
+        icon: 'mdi:home-lightning-bolt'
+
+      - name: "R Backup Voltage"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [ 3135 ]
+        icon: 'mdi:home-lightning-bolt'
+
+      - name: "R Backup Current"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.1
+        rule: 1
+        registers: [ 3136 ]
+        icon: 'mdi:home-lightning-bolt'
+
+      - name: "R Backup Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 0.1
+        rule: 1
+        registers: [ 3137 ]
+        icon: 'mdi:home-lightning-bolt'
+
+      - name: "R Load Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [ 3144 ]
+        icon: 'mdi:home-lightning-bolt'
+

--- a/custom_components/solarman/inverter_definitions/kstar_hybrid.yml
+++ b/custom_components/solarman/inverter_definitions/kstar_hybrid.yml
@@ -127,6 +127,16 @@ parameters:
 
   - group: Power Grid
     items:
+      # Should this be the sum of the 3 phases "Meter Power"?
+      - name: "Total Grid Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [ 3100 ]
+        icon: 'mdi:transmission-tower'
+
       - name: "Daily Energy Purchased"
         class: "energy"
         state_class: "total_increasing"
@@ -198,16 +208,6 @@ parameters:
         rule: 3
         registers: [ 3122, 3121 ]
         icon: 'mdi:transmission-tower-export'
-
-      # Should this be the sum of the 3 phases "Meter Power"?
-      - name: "Total Grid Power"
-        class: "power"
-        state_class: "measurement"
-        uom: "W"
-        scale: 1
-        rule: 2
-        registers: [ 3100 ]
-        icon: 'mdi:home-lightning-bolt'
 
   - group: Electricity Consumption
     items:


### PR DESCRIPTION
New definition file for the KSTAR Hybrid inverter

Parameters taken from the modbus protocol as per https://github.com/StephanJoubert/home_assistant_solarman/discussions/150#discussioncomment-5389729 (thanks @Jay66Bee!)

Modbus protocol [KSTAR.Hybrid.Inverter.Modbus.V2.5_2023.03.03.pdf](https://github.com/StephanJoubert/home_assistant_solarman/files/11069772/KSTAR.Hybrid.Inverter.Modbus.V2.5_2023.03.03.pdf)
