### PR TITLE
Update sofar_lsw3.yaml

### DIFF
--- a/custom_components/solarman/inverter_definitions/sofar_lsw3.yaml
+++ b/custom_components/solarman/inverter_definitions/sofar_lsw3.yaml
@@ -63,7 +63,7 @@ parameters:
 
     - name: "Daily Production"
       class: "energy"
-      state_class: "total"      
+      state_class: "total_increasing"      
       uom: "kWh"
       scale: 0.01
       rule: 1


### PR DESCRIPTION
This adds the possibility to use "Daily Production" in the energy dashboard without a negative production on every start of the day. Why "Daily Production" and not "Total Production"? "Daily Production" is much more accurate (0.01 kWh).