### PR TITLE
Add additional entities for Deye_2mppt

### DIFF
--- a/custom_components/solarman/inverter_definitions/deye_2mppt.yaml
+++ b/custom_components/solarman/inverter_definitions/deye_2mppt.yaml
@@ -55,6 +55,24 @@ parameters:
       registers: [0x003C]
       icon: 'mdi:solar-power'
 
+    - name: "Daily Production 1"
+      class: "energy"
+      state_class: "total"
+      uom: "kWh"
+      scale: 0.1
+      rule: 1
+      registers: [0x0041]
+      icon: 'mdi:solar-power'
+
+    - name: "Daily Production 2"
+      class: "energy"
+      state_class: "total"
+      uom: "kWh"
+      scale: 0.1
+      rule: 1
+      registers: [0x0042]
+      icon: 'mdi:solar-power'
+
     - name: "Total Production"
       class: "energy"
       state_class: "total_increasing"
@@ -65,6 +83,33 @@ parameters:
       icon: 'mdi:solar-power'
       validation:
         min: 0.1
+
+    - name: "Total Production 1"
+      class: "energy"
+      state_class: "total_increasing"
+      uom: "kWh"
+      scale: 0.1
+      rule: 3
+      registers: [0x0045]
+      icon: 'mdi:solar-power'
+
+    - name: "Total Production 2"
+      class: "energy"
+      state_class: "total_increasing"
+      uom: "kWh"
+      scale: 0.1
+      rule: 3
+      registers: [0x0047]
+      icon: 'mdi:solar-power'
+
+    - name: "Active Power Regulations"
+      class: ""
+      state_class: ""
+      uom: "%"
+      scale: 1
+      rule: 1
+      registers: [0x0028]
+      icon: 'mdi:solar-power'
 
   - group: Grid
     items:
@@ -77,6 +122,15 @@ parameters:
       registers: [0x0049]
       icon: 'mdi:transmission-tower'
 
+    - name: "Grid Current"
+      class: "current"
+      state_class: "measurement"      
+      uom: "A"
+      scale: 0.1
+      rule: 2
+      registers: [0x004C]
+      icon: 'mdi:home-lightning-bolt'
+
     - name: "AC Output Frequency"
       class: "frequency"
       state_class: "measurement"
@@ -85,6 +139,105 @@ parameters:
       rule: 1
       registers: [0x004F]
       icon: 'mdi:home-lightning-bolt'
+
+    - name: "Grid Voltage Upp Limit"
+      class: "voltage"
+      state_class: ""
+      uom: "V"
+      scale: 0.1
+      rule: 1
+      registers: [0x001B]
+      icon: 'mdi:transmission-tower'
+
+    - name: "Grid Voltage Lower Limit"
+      class: "voltage"
+      state_class: ""
+      uom: "V"
+      scale: 0.1
+      rule: 1
+      registers: [0x001C]
+      icon: 'mdi:transmission-tower'
+
+    - name: "Grid Frequency Upper Limit"
+      class: "frequency"
+      state_class: ""
+      uom: "Hz"
+      scale: 0.01
+      rule: 1
+      registers: [0x001D]
+      icon: 'mdi:home-lightning-bolt'
+
+    - name: "Grid Frequency Lower Limit"
+      class: "frequency"
+      state_class: ""
+      uom: "Hz"
+      scale: 0.01
+      rule: 1
+      registers: [0x001E]
+      icon: 'mdi:home-lightning-bolt'
+
+    - name: "Overfrequency And Load Reduction Starting Point"
+      class: "frequency"
+      state_class: ""
+      uom: "Hz"
+      scale: 0.01
+      rule: 1
+      registers: [0x0022]
+      icon: 'mdi:home-lightning-bolt'
+
+    - name: "Overfrequency And Load Reduction Percentage"
+      class: ""
+      state_class: ""
+      uom: "%"
+      scale: 1
+      rule: 1
+      registers: [0x0023]
+      icon: ''
+
+    - name: "ON-OFF Enable"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x002B]
+      isstr: true
+      lookup:
+      - key: 0
+        value: "OFF"
+      - key: 1
+        value: "ON"
+      icon: 'mdi:toggle-switch'
+
+    - name: "Island Protection Enable"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x002E]
+      isstr: true
+      lookup:
+      - key: 0
+        value: "Disabled"
+      - key: 1
+        value: "Enabled"
+      icon: 'mdi:island'
+
+    - name: "Overfrequency&Load-shedding Enable"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x0031]
+      isstr: true
+      lookup:
+      - key: 0
+        value: "Disabled"
+      - key: 1
+        value: "Enabled"
+      icon: 'mdi:toggle-switch'
 
   - group: Inverter
     items:
@@ -135,3 +288,105 @@ parameters:
       rule: 5
       registers: [0x0003,0x0004,0x0005,0x0006,0x0007]
       isstr: true
+
+    - name: "Hardware Version"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 7
+      registers: [0x000C]
+      isstr: true
+
+    - name: "DC Master Firmware Version"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 7
+      registers: [0x000D]
+      isstr: true
+
+    - name: "AC Version. Number"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 7
+      registers: [0x000E]
+      isstr: true
+
+    - name: "Rated Power"
+      class: "energy"
+      state_class: ""
+      uom: "W"
+      scale: 0.1
+      rule: 1
+      registers: [0x0010]
+      icon: 'mdi:solar-power'
+
+    - name: "Communication Protocol Version"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 7
+      registers: [0x0012]
+      isstr: true
+
+    - name: "Start-up Self-checking Time "
+      class: ""
+      state_class: ""
+      uom: "s"
+      scale: 1
+      rule: 1
+      registers: [0x0015]
+      icon: 'mdi:solar-power'
+
+    - name: "Update Time"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 8
+      registers: [0x0016,0x0017,0x0018]
+      isstr: true
+
+    - name: "Soft Start Enable"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x002F]
+      isstr: true
+      lookup:
+      - key: 0
+        value: "Disabled"
+      - key: 1
+        value: "Enabled"
+      icon: 'mdi:toggle-switch'
+
+    - name: "Power Factor Regulation"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 0.1
+      rule: 2
+      registers: [0x0032]
+      icon: ''
+
+    - name: "Restore Factory Settings"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x0036]
+      isstr: true
+      lookup:
+      - key: 0
+        value: "Disabled"
+      - key: 1
+        value: "Enabled"
+      icon: 'mdi:factory'

--- a/custom_components/solarman/parser.py
+++ b/custom_components/solarman/parser.py
@@ -35,6 +35,10 @@ class ParameterParser:
             self.try_parse_ascii(rawData,definition, start, length)
         elif rule == 6:
             self.try_parse_bits(rawData,definition, start, length)
+        elif rule == 7:
+            self.try_parse_version(rawData,definition, start, length)
+        elif rule == 8:
+            self.try_parse_datetime(rawData,definition, start, length)
         return
     
     def do_validate(self, title, value, rule):
@@ -166,6 +170,49 @@ class ParameterParser:
             self.result[title] = value
         return 
     
+    def try_parse_version (self, rawData, definition, start, length):
+        title = definition['name']         
+        found = True
+        value = ''
+        for r in definition['registers']:
+            index = r - start   # get the decimal value of the register'
+            if (index >= 0) and (index < length):
+                offset = OFFSET_PARAMS + (index * 2)
+                temp = struct.unpack('>H', rawData[offset:offset + 2])[0]
+                value = value + str(temp >> 12) + "." +  str(temp >> 8 & 0x0F) + "." + str(temp >> 4 & 0x0F) + "." + str(temp & 0x0F)
+            else:
+                found = False
+ 
+        if found:
+            self.result[title] = value
+        return
+
+    def try_parse_datetime (self, rawData, definition, start, length):
+        title = definition['name']         
+        found = True
+        value = ''
+        print("start: ", start)
+        for i,r in enumerate(definition['registers']):
+            index = r - start   # get the decimal value of the register'
+            print ("index: ",index)
+            if (index >= 0) and (index < length):
+                offset = OFFSET_PARAMS + (index * 2)
+                temp = struct.unpack('>H', rawData[offset:offset + 2])[0]
+                if(i==0):
+                    value = value + str(temp >> 8)  + "/" + str(temp & 0xFF) + "/"
+                elif (i==1):
+                    value = value + str(temp >> 8)  + " " + str(temp & 0xFF) + ":"
+                elif(i==2):
+                    value = value + str(temp >> 8)  + ":" + str(temp & 0xFF)
+                else:
+                    value = value + str(temp >> 8)  + str(temp & 0xFF)
+            else:
+                found = False
+ 
+        if found:
+            self.result[title] = value
+        return
+ 
     def get_sensors (self):
         result = []
         for i in self._lookups['parameters']:


### PR DESCRIPTION
Compared to the stock solarman app the deye_2mppt.yaml file lacked a lot of information.

I added a lot additional information after looking up the register contents and compared them to the values shown in solarman app. 

Additional Information:

- Daily Production 1
- Daily Production 2
- Total Production 1
- Total Production 2
- Active Power Regulations
- Grid Current
- Grid Voltage Upp Limit
- Grid Voltage Lower Limit
- Grid Frequency Upper Limit
- Grid Frequency Lower Limit
- Overfrequency And Load Reduction Starting Point
- Overfrequency And Load Reduction Percentage
- ON-OFF Enable
- Island Protection Enable
- Overfrequency&Load-shedding Enable
- Hardware Version
- DC Master Firmware Version
- AC Version Number
- Rated Power
- Communication Protocol Version
- Start-up Self-checking Time
- Update Time
- Soft Start Enable
- Power Factor Regulation
- Restore Factory Settings

To parse the version and datetime information in the registers, i also added some additional rules:

- 7: try_parse_version
- 8: try_parse_datetime

Most (if not all) additional parameter should also work identically for Deye_4MPPT devices, but would need to be tested.