### PR TITLE
Add new rule for parsing time values.

### DIFF
--- a/custom_components/solarman/inverter_definitions/deye_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/deye_hybrid.yaml
@@ -2,8 +2,11 @@ requests:
   - start: 0x0003
     end: 0x0070
     mb_functioncode: 0x03
-  - start: 0x0096  
-    end: 0x00f8
+  - start: 0x0096
+    end: 0x00f9
+    mb_functioncode: 0x03
+  - start: 0x00FA
+    end: 0x0117
     mb_functioncode: 0x03
 
 parameters:
@@ -210,6 +213,14 @@ parameters:
       registers: [0x0096]
       icon: 'mdi:transmission-tower'
 
+    - name: "Grid Current L1"
+      class: "current"
+      state_class: "measurement"
+      uom: "A"
+      scale: 0.01
+      rule: 1
+      registers: [0x00A0]
+      icon: 'mdi:current-ac'
     - name: "Grid Voltage L2"
       class: "voltage"
       state_class: "measurement"
@@ -219,6 +230,15 @@ parameters:
       registers: [0x0097]
       icon: 'mdi:transmission-tower'
 
+    - name: "Grid Current L2"
+      class: "current"
+      state_class: "measurement"
+      uom: "A"
+      scale: 0.01
+      rule: 1
+      registers: [0x00A1]
+      icon: 'mdi:current-ac'
+      
     - name: "Internal CT L1 Power"
       class: "power"
       state_class: "measurement"
@@ -402,6 +422,15 @@ parameters:
       registers: [0x00AF]
       icon: 'mdi:home-lightning-bolt'
 
+    - name: "Grid Frequency"
+      class: "frequency"
+      state_class: "measurement"
+      uom: "Hz"
+      scale: 0.01
+      rule: 1
+      registers: [0x004F]
+      icon: 'mdi:sine-wave'
+
     - name: "Current L1"
       class: "current"
       state_class: "measurement"      
@@ -444,7 +473,7 @@ parameters:
       scale: 0.01
       rule: 1
       registers: [0x00C0]
-      icon: 'mdi:lightning-bolt-outline'
+      icon: 'mdi:sine-wave'
 
     - name: "DC Temperature"
       class: "temperature"
@@ -529,20 +558,6 @@ parameters:
       rule: 1
       registers: [0x00A6]
 
-    - name: "Time of use"
-      class: ""
-      state_class: ""      
-      uom: ""
-      scale: 1
-      rule: 1
-      registers: [0x00F8]
-      isstr: true
-      lookup: 
-      -  key: 0
-         value: "Disable"
-      -  key: 1
-         value: "Enable"
-
     - name: "Work Mode"
       class: ""
       state_class: ""      
@@ -573,3 +588,236 @@ parameters:
       scale: 1
       rule: 6
       registers: [0x0065,0x0066,0x0067,0x0068,0x0069,0x006A]
+
+ - group: Time of Use
+   items:
+    - name: "Time of use Time 1"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 9
+      registers: [0x00FA]
+      icon: 'mdi:timelapse'
+
+    - name: "Time of use Time 2"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 9
+      registers: [0x00FB]
+      icon: "mdi:timelapse"
+      
+    - name: "Time of Use Time 3"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 9
+      registers: [0x00FC]
+      icon: 'mdi:timelapse'
+
+    - name: "Time of Use Time 4"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 9
+      registers: [0x00FD]
+      icon: 'mdi:timelapse'
+
+    - name: "Time of Use Time 5"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 9
+      registers: [0x00FE]
+      icon: "mdi:timelapse"
+
+    - name: "Time of Use Time 6"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 9
+      registers: [0x00FF]
+      icon: 'mdi:timelapse'
+
+    - name: "Time of Use Power 1"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x0100]
+      icon: "mdi:lightning-bolt-outline"
+
+    - name: "Time of Use Power 2"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x0101]
+      icon: 'mdi:lightning-bolt-outline'
+
+    - name: "Time of Use Power 3"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x0102]
+      icon: 'mdi:lightning-bolt-outline'
+
+    - name: "Time of Use Power 4"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x0103]
+      icon: 'mdi:lightning-bolt-outline'
+
+    - name: "Time of Use Power 5"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x0104]
+      icon: 'mdi:lightning-bolt-outline'
+
+    - name: "Time of Use Power 6"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x0105]
+      icon: 'mdi:lightning-bolt-outline'
+
+    - name: "Time of Use SOC 1"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x010C]
+      icon: 'mdi:battery'
+
+    - name: "Time of Use SOC 2"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x010D]
+      icon: 'mdi:battery'
+
+    - name: "Time of Use SOC 3"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x010E]
+      icon: 'mdi:battery'
+
+    - name: "Time of Use SOC 4"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x010F]
+      icon: 'mdi:battery'
+
+    - name: "Time of Use SOC 5"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x0110]
+      icon: 'mdi:battery'
+
+    - name: "Time of Use SOC 6"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x0111]
+      icon: 'mdi:battery'
+
+    - name: "Time of Use Enable 1"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x0112]
+      icon: 'mdi:checkbox-marked-outline'
+
+    - name: "Time of Use Enable 2"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x0113]
+      icon: 'mdi:checkbox-marked-outline'
+
+    - name: "Time of Use Enable 3"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x0114]
+      icon: 'mdi:checkbox-marked-outline'
+
+    - name: "Time of Use Enable 4"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x0115]
+      icon: 'mdi:checkbox-marked-outline'
+
+    - name: "Time of Use Enable 5"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x0116]
+      icon: 'mdi:checkbox-marked-outline'
+
+    - name: "Time of Use Enable 6"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x0117]
+      icon: 'mdi:checkbox-marked-outline'
+
+    - name: "Time of use"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x00F8]
+      icon: 'mdi:checkbox-marked-outline'
+      isstr: true
+      lookup:
+        - key: 0
+          value: "Disable"
+        - key: 1
+          value: "Enable"

--- a/custom_components/solarman/parser.py
+++ b/custom_components/solarman/parser.py
@@ -39,6 +39,8 @@ class ParameterParser:
             self.try_parse_version(rawData,definition, start, length)
         elif rule == 8:
             self.try_parse_datetime(rawData,definition, start, length)
+        elif rule == 9:
+            self.try_parse_time(rawData,definition, start, length)
         return
     
     def do_validate(self, title, value, rule):
@@ -209,6 +211,23 @@ class ParameterParser:
             else:
                 found = False
  
+        if found:
+            self.result[title] = value
+        return
+
+    def try_parse_time (self, rawData, definition, start, length):
+        title = definition['name']         
+        found = True
+        value = ''
+        for r in definition['registers']:
+            index = r - start   # get the decimal value of the register'
+            if (index >= 0) and (index < length):
+                offset = OFFSET_PARAMS + (index * 2)
+                temp = struct.unpack('>H', rawData[offset:offset + 2])[0]
+                value = str("{:02d}".format(int(temp / 100))) + ":" + str("{:02d}".format(int(temp % 100)))
+            else:
+                found = False
+
         if found:
             self.result[title] = value
         return

--- a/customization.md
+++ b/customization.md
@@ -102,14 +102,17 @@ Example yaml file for the example mentioned above:
 
 \## see https://developers.home-assistant.io/docs/core/entity/sensor/#entities-representing-a-total-amount
 
-\### The rule field specifies how to interpret the binary data. 
+### The rule field specifies how to interpret the binary data. 
 
-1. unsigned 16-bit value
-2. signed 16 bit value
-3. unsigned 32 bit value
-4. signed 32 bit value
-5. ascii value
-6. bit field
-
-
+| Rule # | Description           | Example                                                                                                                |
+|--------|-----------------------|------------------------------------------------------------------------------------------------------------------------|
+|    1   | unsigned 16-bit value |                                                                                                                        |
+|    2   | signed 16 bit value   |                                                                                                                        |
+|    3   | unsigned 32 bit value |                                                                                                                        |
+|    4   | signed 32 bit value   |                                                                                                                        |
+|    5   | ascii value           |                                                                                                                        |
+|    6   | bit field             |                                                                                                                        |
+|    7   | Version               |                                                                                                                        |
+|    8   | Date Time             |                                                                                                                        |
+|    9   | Time                  | Time value as string<ul><li>Example 1: Register Value 2200 => Time Value: 22:00</li><li>Example 2: Register value: 400 => 04:00</li></ul> |
 


### PR DESCRIPTION
Add following to deye_hybrid.yaml:
 - Grid Current L1
 - Grid Current L2
 - Grid Frequency
 - Time of Use Time [1 - 6]
 - Time of Use Power [1 - 6]
 - Time of Use SOC [1 - 6]
 - Time of Use Enabled [1 - 6] 

Update customization.md with new rule as well as missing rules

This allows using the Sunsynk dashboard (https://github.com/slipx06/Sunsynk-Home-Assistant-Dash) as well as the Sunsynk Power Flow Card (https://github.com/slipx06/sunsynk-power-flow-card):
![image](https://github.com/StephanJoubert/home_assistant_solarman/assets/485436/66e0b850-0450-4bff-9239-c9e75d23889c)

![image](https://github.com/StephanJoubert/home_assistant_solarman/assets/485436/e09da09c-1824-4888-9307-372540a9aba6)
