### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Once logged in, expand the "Device information" and note the Device serial numbe
 
 ![WebPortal](./web_portal.png)
 
-2. Check the version of the solarman logger. If the serial number starts with 17xxxxxxx or 21xxxxxxx (protocol V5), the component should work. If not, you may need to try the component for V4 of the protocol mentioned above.
+2. Check the version of the solarman logger. If the serial number starts with 17xxxxxxx, 21xxxxxxx or 40xxxxxxx (protocol V5), the component should work. If not, you may need to try the component for V4 of the protocol mentioned above.
 
 3. On your DHCP server, reserve the IP for the WiFi data logger so that it will not change.
 


### PR DESCRIPTION
home_assistant_solarman integration works with Solis DLS-W (WLAN) - Stick and solis_hybrid.yaml. Inverter is a Solis RHI-3P (5-10) K-HVES-5G with Pylontech Force-H2 battery. No need for additional hardware.