### PR TITLE
Fix Today totalizer for hyd-zss-hp-3k-6k inverter

### DIFF
--- a/custom_components/solarman/inverter_definitions/hyd-zss-hp-3k-6k.yaml
+++ b/custom_components/solarman/inverter_definitions/hyd-zss-hp-3k-6k.yaml
@@ -26,7 +26,7 @@ parameters:
     items:
       - name: 'PV Generation today'
         class: 'energy'
-        state_class: 'total'
+        state_class: 'total_increasing'
         uom: 'kWh'
         scale: 0.01
         rule: 3
@@ -182,7 +182,7 @@ parameters:
 
       - name: 'Battery Charge Today'
         class: 'energy'
-        state_class: 'total'
+        state_class: 'total_increasing'
         uom: 'kWh'
         scale: 0.01        
         rule: 3
@@ -191,7 +191,7 @@ parameters:
 
       - name: 'Battery Discharge Today'
         class: 'energy'
-        state_class: 'total'
+        state_class: 'total_increasing'
         uom: 'kWh'
         scale: 0.01        
         rule: 3
@@ -229,7 +229,7 @@ parameters:
         
       - name: 'Energy Purchase Today'
         class: 'energy'
-        state_class: 'total'
+        state_class: 'total_increasing'
         uom: 'kWh'
         scale: 0.01        
         rule: 3
@@ -247,7 +247,7 @@ parameters:
 
       - name: 'Energy Selling Today'
         class: 'energy'
-        state_class: 'total'
+        state_class: 'total_increasing'
         uom: 'kWh'
         scale: 0.01        
         rule: 3


### PR DESCRIPTION
Actually the `hyd-zss-hp-3k-6k` inverter definition has marked all "Today" totalizer with

``` yaml
state_class: 'total'
```

This cause a big diff on 1st measure of each day.

According to [docs](https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes) and other inverter definition this sensor need to be.

``` yaml
state_class: 'total_increasing'
```