### PR TITLE
Passthrough missing lookup table value

### DIFF
--- a/custom_components/solarman/parser.py
+++ b/custom_components/solarman/parser.py
@@ -132,7 +132,7 @@ class ParameterParser:
         for o in options:
             if (o['key'] == value):
                 return o['value']
-        return "LOOKUP"
+        return value
 
 
     def try_parse_ascii (self, rawData, definition, start, length):


### PR DESCRIPTION
Pass through unknown lookup table values, rather than lose it through meaningless `LOOKUP` value