### PR TITLE
remove invalidate_all from battery temp for deye_sg04lp3.yaml

### DIFF
--- a/custom_components/solarman/inverter_definitions/deye_sg04lp3.yaml
+++ b/custom_components/solarman/inverter_definitions/deye_sg04lp3.yaml
@@ -188,7 +188,6 @@ parameters:
       validation:
         min: 1
         max: 99
-        invalidate_all:
  
  - group: Grid
    items: 


### PR DESCRIPTION
remove invalidate_all from battery temp for deye_sg04lp3.yaml definition as inverters in parallel read -100 degrees celsius for connected batteries on the slaves (master battery-temp is correct though)