### PR TITLE
Import os before using it

### DIFF
--- a/custom_components/solarman/const.py
+++ b/custom_components/solarman/const.py
@@ -1,3 +1,4 @@
+import os
 from datetime import timedelta
 
 DOMAIN = 'solarman'


### PR DESCRIPTION
When using 'main' in hacs, this fails with

```
2023-12-14 11:11:07.907 ERROR (MainThread) [homeassistant.loader] Unexpected exception importing platform custom_components.solarman.config_flow
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/loader.py", line 834, in get_platform
    cache[full_name] = self._import_platform(platform_name)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/loader.py", line 851, in _import_platform
    return importlib.import_module(f"{self.pkg_path}.{platform_name}")
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1126, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/config/custom_components/solarman/__init__.py", line 9, in <module>
    from .const import *
  File "/config/custom_components/solarman/const.py", line 9, in <module>
    LOOKUP_FILES = (os.listdir(os.path.dirname(__file__) + '/inverter_definitions'))
                    ^^
NameError: name 'os' is not defined
```