### PR TITLE
Add Backup SOC and Overdischarge SOC

### DIFF
--- a/custom_components/solarman/inverter_definitions/solis_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/solis_hybrid.yaml
@@ -13,7 +13,7 @@ requests:
   - start: 33206
     end:  33282
     mb_functioncode: 0x04
-  - start: 43140
+  - start: 43000
     end: 43150
     mb_functioncode: 0x03
 
@@ -843,6 +843,24 @@ parameters:
       rule: 1
       registers: [33144]
       icon: 'mdi:battery-arrow-down'
+
+    - name: "Backup Mode SOC"
+      class: "battery"
+      state_class: "measurement"
+      uom: "%"
+      scale: 1
+      rule: 1
+      registers: [43024]
+      icon: 'mdi:battery'
+
+    - name: "Overdischarge SOC"
+      class: "battery"
+      state_class: "measurement"
+      uom: "%"
+      scale: 1
+      rule: 1
+      registers: [43011]
+      icon: 'mdi:battery'  
 
  - group: TimedCharge
    items: 


### PR DESCRIPTION
Adds two holding registers to the Solis hybrid definition. Also requires definition of the register range for holding registers to be expanded to include them (lower limit reduced to 43000)