### PR TITLE
remove 4999 register request

### DIFF
--- a/custom_components/solarman/inverter_definitions/solis_3p-4g.yaml
+++ b/custom_components/solarman/inverter_definitions/solis_3p-4g.yaml
@@ -7,9 +7,6 @@ requests:
   - start: 2999
     end:  3044
     mb_functioncode: 0x04
-  - start: 4999
-    end:  4999
-    mb_functioncode: 0x04
 
 
 parameters:
@@ -38,15 +35,6 @@ parameters:
             value: "Power-PF"
           - key: 6
             value: "Rule21Volt–watt"
-
-    - name: "Grid status"
-      class: ""
-      state_class: ""
-      uom: ""
-      scale: 1
-      rule: 1
-      registers: [4999]
-      icon: 'mdi:home-lightning-bolt'
 
     - name: "Inverter Temperature"
       class: "temperature"


### PR DESCRIPTION
In recent version os solarman, sending request to 4999 register doesn't work. Custom integration doesn't load in HA with this inverter definition.
As long as  the register 4999 value is not very usefull, let just remove it and get back to work inverter definition.