### PR TITLE
Fix UI dropdown to load YAML files

### DIFF
--- a/custom_components/solarman/const.py
+++ b/custom_components/solarman/const.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+import os
 
 DOMAIN = 'solarman'
 
@@ -6,7 +7,7 @@ DEFAULT_PORT_INVERTER = 8899
 DEFAULT_INVERTER_MB_SLAVEID = 1
 DEFAULT_LOOKUP_FILE = 'deye_hybrid.yaml'
 
-LOOKUP_FILES = (os.listdir(os.path.dirname(__file__) + '/inverter_definitions'))
+LOOKUP_FILES = (sorted([f for f in os.listdir(os.path.dirname(__file__) + '/inverter_definitions') if f.endswith('.yaml')]))
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=15)
 


### PR DESCRIPTION
Improves #465 and #455 by filtering only `.yaml` files and sorting them alphabetically.
Fixes #423 (log message `NameError: name 'os' is not defined`).