### PR TITLE
Automatically set scale to 1 when undefined in YAML

### DIFF
--- a/custom_components/solarman/parser.py
+++ b/custom_components/solarman/parser.py
@@ -55,7 +55,7 @@ class ParameterParser:
 
     def try_parse_signed (self, rawData, definition, start, length):
         title = definition['name']
-        scale = definition['scale']
+        scale = definition['scale'] if 'scale' in definition else 1
         value = 0
         found = True
         shift = 0
@@ -92,7 +92,7 @@ class ParameterParser:
     
     def try_parse_unsigned (self, rawData, definition, start, length):
         title = definition['name']
-        scale = definition['scale']
+        scale = definition['scale'] if 'scale' in definition else 1
         value = 0
         found = True
         shift = 0

--- a/customization.md
+++ b/customization.md
@@ -71,7 +71,7 @@ The group just groups parameters that belong together. The induvidual parameter-
 |uom||The *unit_of_measurement* field of the home-assistant entity #|
 |icon||The *icon* field of the home-assistant entity #|
 || **The fields below define how the value from the logger is parsed** |
-|scale||Scaling factor for the value read from the logger|
+|scale||Scaling factor for the value read from the logger (default: 1)|
 |rule||Method to interpret the data from the logger ###|
 |mask||A mask to filter only used bit fields. This is especialy useful for flag fields|
 |registers||Array of register fields that comprises the value. If the value is placed in a number of registers, this  array will contain more than one item.|


### PR DESCRIPTION
Deals with YAML inverter definition files that are missing the `scale` parameter-item and cause an exception.