### PR TITLE
Add support for Solarman Smart Meter DTSD422-D3 and signed magnitude integer values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,19 +100,20 @@ sensor:
 
 ### Lookup Files
 
-| Lookup File             | Inverters supported                      | Notes                                                            |
-|-------------------------|------------------------------------------|------------------------------------------------------------------|
-| deye_hybrid.yaml        | DEYE/Sunsynk/SolArk Hybrid inverters     | used when no lookup specified                                    |
-| deye_sg04lp3.yaml       | DEYE/Sunsynk/SolArk Hybrid 8/12K-SG04LP3 | e.g. 12K-SG04LP3-EU                                              |
-| deye_string.yaml        | DEYE/Sunsynk/SolArk String inverters     | e.g. SUN-4/5/6/7/8/10/12K-G03 Plus                               |
-| deye_2mppt.yaml         | DEYE Microinverter with 2 MPPT Trackers  | e.g. SUN600G3-EU-230 / SUN800G3-EU-230 / SUN1000G3-EU-230        |
-| deye_4mppt.yaml         | DEYE Microinverter with 4 MPPT Trackers  | e.g. SUN1300G3-EU-230 / SUN1600G3-EU-230 / SUN2000G3-EU-230      |
-| sofar_lsw3.yaml         | SOFAR Inverters                          |                                                                  |
-| sofar_g3hyd.yaml        | SOFAR Hybrid Three-Phase inverter        | HYD 6000 or rebranded (three-phase), ex. ZCS Azzurro 3PH HYD-ZSS |
-| sofar_hyd3k-6k.yaml     | SOFAR Hybrid Single-Phase inverter       | HYD 6000 or rebranded (single-phase), ex. ZCS Azzurro HYD-ZSS    |
-| solis_hybrid.yaml       | SOLIS Hybrid inverter                    |                                                                  |
-| solid_1p8k-5g.yaml      | SOLIS 1P8K-5G                            |                                                                  |
-| zcs_azzurro-ktl-v3.yaml | ZCS Azzurro KTL-V3 inverters             | ZCS Azzurro 3.3/4.4/5.5/6.6 KTL-V3 (rebranded Sofar KTLX-G3)     |
+| Lookup File              | Inverters supported                      | Notes                                                            |
+|--------------------------|------------------------------------------|------------------------------------------------------------------|
+| deye_hybrid.yaml         | DEYE/Sunsynk/SolArk Hybrid inverters     | used when no lookup specified                                    |
+| deye_sg04lp3.yaml        | DEYE/Sunsynk/SolArk Hybrid 8/12K-SG04LP3 | e.g. 12K-SG04LP3-EU                                              |
+| deye_string.yaml         | DEYE/Sunsynk/SolArk String inverters     | e.g. SUN-4/5/6/7/8/10/12K-G03 Plus                               |
+| deye_2mppt.yaml          | DEYE Microinverter with 2 MPPT Trackers  | e.g. SUN600G3-EU-230 / SUN800G3-EU-230 / SUN1000G3-EU-230        |
+| deye_4mppt.yaml          | DEYE Microinverter with 4 MPPT Trackers  | e.g. SUN1300G3-EU-230 / SUN1600G3-EU-230 / SUN2000G3-EU-230      |
+| solarman_dtsd422-d3.yaml | Solarman Smart Meter DTSD422-D3          |                                                                  |
+| sofar_lsw3.yaml          | SOFAR Inverters                          |                                                                  |
+| sofar_g3hyd.yaml         | SOFAR Hybrid Three-Phase inverter        | HYD 6000 or rebranded (three-phase), ex. ZCS Azzurro 3PH HYD-ZSS |
+| sofar_hyd3k-6k.yaml      | SOFAR Hybrid Single-Phase inverter       | HYD 6000 or rebranded (single-phase), ex. ZCS Azzurro HYD-ZSS    |
+| solis_hybrid.yaml        | SOLIS Hybrid inverter                    |                                                                  |
+| solid_1p8k-5g.yaml       | SOLIS 1P8K-5G                            |                                                                  |
+| zcs_azzurro-ktl-v3.yaml  | ZCS Azzurro KTL-V3 inverters             | ZCS Azzurro 3.3/4.4/5.5/6.6 KTL-V3 (rebranded Sofar KTLX-G3)     |
 
 # Auto-discovery
 

--- a/custom_components/solarman/inverter_definitions/solarman_dtsd422-d3.yaml
+++ b/custom_components/solarman/inverter_definitions/solarman_dtsd422-d3.yaml
@@ -1,0 +1,433 @@
+# First version: 19.04.2024
+# Smartmeter DTSD422-D3
+
+requests:
+  - start: 0x0001
+    end:   0x0029
+    mb_functioncode: 0x03
+  - start: 0x1001
+    end:   0x1029
+    mb_functioncode: 0x03
+
+parameters:
+  - group: Voltage
+    items:
+    - name: CT1 Voltage
+      class: voltage
+      uom: V
+      scale: 0.1
+      rule: 1
+      registers: [0x0001]
+      icon: mdi:sine-wave
+
+    - name: CT2 Voltage
+      class: voltage
+      uom: V
+      scale: 0.1
+      rule: 1
+      registers: [0x0002]
+      icon: mdi:sine-wave
+
+    - name: CT3 Voltage
+      class: voltage
+      uom: V
+      scale: 0.1
+      rule: 1
+      registers: [0x0003]
+      icon: mdi:sine-wave
+
+    - name: CT4 Voltage
+      class: voltage
+      uom: V
+      scale: 0.1
+      rule: 1
+      registers: [0x1001]
+      icon: mdi:sine-wave
+
+    - name: CT5 Voltage
+      class: voltage
+      uom: V
+      scale: 0.1
+      rule: 1
+      registers: [0x1002]
+      icon: mdi:sine-wave
+
+    - name: CT6 Voltage
+      class: voltage
+      uom: V
+      scale: 0.1
+      rule: 1
+      registers: [0x1003]
+      icon: mdi:sine-wave
+
+  - group: Current
+    items:
+    - name: CT1 Current
+      class: current
+      state_class: measurement
+      uom: A
+      scale: 0.001
+      rule: 10
+      registers: [0x0008,0x0007]
+      icon: mdi:current-ac
+
+    - name: CT2 Current
+      class: current
+      state_class: measurement
+      uom: A
+      scale: 0.001
+      rule: 10
+      registers: [0x000A,0x0009]
+      icon: mdi:current-ac
+
+    - name: CT3 Current
+      class: current
+      state_class: measurement
+      uom: A
+      scale: 0.001
+      rule: 10
+      registers: [0x000C,0x000B]
+      icon: mdi:current-ac
+
+    - name: CT4 Current
+      class: current
+      state_class: measurement
+      uom: A
+      scale: 0.001
+      rule: 10
+      registers: [0x1008,0x1007]
+      icon: mdi:current-ac
+
+    - name: CT5 Current
+      class: current
+      state_class: measurement
+      uom: A
+      scale: 0.001
+      rule: 10
+      registers: [0x100A,0x1009]
+      icon: mdi:current-ac
+
+    - name: CT6 Current
+      class: current
+      state_class: measurement
+      uom: A
+      scale: 0.001
+      rule: 10
+      registers: [0x100C,0x100B]
+      icon: mdi:current-ac
+
+  - group: Active Power
+    items:
+    - name: CT1-3 Total Active Power
+      class: power
+      state_class: measurement
+      uom: W
+      scale: 1
+      rule: 10
+      registers: [0x000E,0x000D]
+      icon: mdi:flash
+
+    - name: CT1 Active Power
+      class: power
+      state_class: measurement
+      uom: W
+      scale: 1
+      rule: 10
+      registers: [0x0010,0x000F]
+      icon: mdi:flash
+
+    - name: CT2 Active Power
+      class: power
+      state_class: measurement
+      uom: W
+      scale: 1
+      rule: 10
+      registers: [0x0012,0x0011]
+      icon: mdi:flash
+
+    - name: CT3 Active Power
+      class: power
+      state_class: measurement
+      uom: W
+      scale: 1
+      rule: 10
+      registers: [0x0014,0x0013]
+      icon: mdi:flash
+
+    - name: CT4-6 Total Active Power
+      class: power
+      state_class: measurement
+      uom: W
+      scale: 1
+      rule: 10
+      registers: [0x100E,0x100D]
+      icon: mdi:flash
+
+    - name: CT4 Active Power
+      class: power
+      state_class: measurement
+      uom: W
+      scale: 1
+      rule: 10
+      registers: [0x1010,0x100F]
+      icon: mdi:flash
+
+    - name: CT5 Active Power
+      class: power
+      state_class: measurement
+      uom: W
+      scale: 1
+      rule: 10
+      registers: [0x1012,0x1011]
+      icon: mdi:flash
+
+    - name: CT6 Active Power
+      class: power
+      state_class: measurement
+      uom: W
+      scale: 1
+      rule: 10
+      registers: [0x1014,0x1013]
+      icon: mdi:flash
+
+  - group: Reactive Power
+    items:
+    - name: CT1-3 Total Reactive Power
+      class: reactive_power
+      state_class: measurement
+      uom: var
+      scale: 1
+      rule: 10
+      registers: [0x0016,0x0015]
+      icon: mdi:flash
+
+    - name: CT1 Reactive Power
+      class: reactive_power
+      state_class: measurement
+      uom: var
+      scale: 1
+      rule: 10
+      registers: [0x0018,0x0017]
+      icon: mdi:flash
+
+    - name: CT2 Reactive Power
+      class: reactive_power
+      state_class: measurement
+      uom: var
+      scale: 1
+      rule: 10
+      registers: [0x001A,0x0019]
+      icon: mdi:flash
+
+    - name: CT3 Reactive Power
+      class: reactive_power
+      state_class: measurement
+      uom: var
+      scale: 1
+      rule: 10
+      registers: [0x001C,0x001B]
+      icon: mdi:flash
+
+    - name: CT4-6 Total Reactive Power
+      class: reactive_power
+      state_class: measurement
+      uom: var
+      scale: 1
+      rule: 10
+      registers: [0x1016,0x1015]
+      icon: mdi:flash
+
+    - name: CT4 Reactive Power
+      class: reactive_power
+      state_class: measurement
+      uom: var
+      scale: 1
+      rule: 10
+      registers: [0x1018,0x1017]
+      icon: mdi:flash
+
+    - name: CT5 Reactive Power
+      class: reactive_power
+      state_class: measurement
+      uom: var
+      scale: 1
+      rule: 10
+      registers: [0x101A,0x1019]
+      icon: mdi:flash
+
+    - name: CT6 Reactive Power
+      class: reactive_power
+      state_class: measurement
+      uom: var
+      scale: 1
+      rule: 10
+      registers: [0x101C,0x101B]
+      icon: mdi:flash
+
+  - group: Apparent Power
+    items:
+    - name: CT1-3 Total Apparent Power
+      class: apparent_power
+      state_class: measurement
+      uom: VA
+      scale: 1
+      rule: 10
+      registers: [0x001E,0x001D]
+      icon: mdi:flash
+
+    - name: CT1 Apparent Power
+      class: apparent_power
+      state_class: measurement
+      uom: VA
+      scale: 1
+      rule: 10
+      registers: [0x0020,0x001F]
+      icon: mdi:flash
+
+    - name: CT2 Apparent Power
+      class: apparent_power
+      state_class: measurement
+      uom: VA
+      scale: 1
+      rule: 10
+      registers: [0x0022,0x0021]
+      icon: mdi:flash
+
+    - name: CT3 Apparent Power
+      class: apparent_power
+      state_class: measurement
+      uom: VA
+      scale: 1
+      rule: 10
+      registers: [0x0024,0x0023]
+      icon: mdi:flash
+
+    - name: CT4-6 Total Apparent Power
+      class: apparent_power
+      state_class: measurement
+      uom: VA
+      scale: 1
+      rule: 10
+      registers: [0x101E,0x101D]
+      icon: mdi:flash
+
+    - name: CT4 Apparent Power
+      class: apparent_power
+      state_class: measurement
+      uom: VA
+      scale: 1
+      rule: 10
+      registers: [0x1020,0x101F]
+      icon: mdi:flash
+
+    - name: CT5 Apparent Power
+      class: apparent_power
+      state_class: measurement
+      uom: VA
+      scale: 1
+      rule: 10
+      registers: [0x1022,0x1021]
+      icon: mdi:flash
+
+    - name: CT6 Apparent Power
+      class: apparent_power
+      state_class: measurement
+      uom: VA
+      scale: 1
+      rule: 10
+      registers: [0x1024,0x1023]
+      icon: mdi:flash
+
+  - group: Power Factor
+    items:
+    - name: CT1-3 Power Factor
+      class: power_factor
+      state_class: measurement
+      uom: ""
+      scale: 0.001
+      rule: 10
+      registers: [0x0025]
+      icon: mdi:angle-acute
+
+    - name: CT1 Power Factor
+      class: power_factor
+      state_class: measurement
+      uom: ""
+      scale: 0.001
+      rule: 10
+      registers: [0x0026]
+      icon: mdi:angle-acute
+
+    - name: CT2 Power Factor
+      class: power_factor
+      state_class: measurement
+      uom: ""
+      scale: 0.001
+      rule: 10
+      registers: [0x0027]
+      icon: mdi:angle-acute
+
+    - name: CT3 Power Factor
+      class: power_factor
+      state_class: measurement
+      uom: ""
+      scale: 0.001
+      rule: 10
+      registers: [0x0028]
+      icon: mdi:angle-acute
+
+    - name: CT4-6 Power Factor
+      class: power_factor
+      state_class: measurement
+      uom: ""
+      scale: 0.001
+      rule: 10
+      registers: [0x1025]
+      icon: mdi:angle-acute
+
+    - name: CT4 Power Factor
+      class: power_factor
+      state_class: measurement
+      uom: ""
+      scale: 0.001
+      rule: 10
+      registers: [0x1026]
+      icon: mdi:angle-acute
+
+    - name: CT5 Power Factor
+      class: power_factor
+      state_class: measurement
+      uom: ""
+      scale: 0.001
+      rule: 10
+      registers: [0x1027]
+      icon: mdi:angle-acute
+
+    - name: CT6 Power Factor
+      class: power_factor
+      state_class: measurement
+      uom: ""
+      scale: 0.001
+      rule: 10
+      registers: [0x1028]
+      icon: mdi:angle-acute
+
+  - group: Frequency
+    items:
+    - name: CT1-3 Frequency
+      class: frequency
+      state_class: measurement
+      uom: Hz
+      scale: 0.01
+      rule: 1
+      registers: [0x0029]
+      icon: mdi:sine-wave
+
+    - name: CT4-6 Frequency
+      class: frequency
+      state_class: measurement
+      uom: Hz
+      scale: 0.01
+      rule: 1
+      registers: [0x1029]
+      icon: mdi:sine-wave

--- a/custom_components/solarman/parser.py
+++ b/custom_components/solarman/parser.py
@@ -36,6 +36,8 @@ class ParameterParser:
             self.try_parse_datetime(rawData,definition, start, length)
         elif rule == 9:
             self.try_parse_time(rawData,definition, start, length)
+        elif rule == 10:
+            self.try_parse_signed(rawData,definition, start, length, True)
         return
     
     def do_validate(self, title, value, rule):
@@ -53,7 +55,7 @@ class ParameterParser:
         
         return True
 
-    def try_parse_signed (self, rawData, definition, start, length):
+    def try_parse_signed (self, rawData, definition, start, length, signed_magnitude_integer = False):
         title = definition['name']
         scale = definition['scale'] if 'scale' in definition else 1
         value = 0
@@ -73,9 +75,12 @@ class ParameterParser:
         if found:
             if 'offset' in definition:
                 value = value - definition['offset']       
-                      
-            if value > maxint/2:
-                value = (value - maxint) * scale
+
+            if value > (maxint >> 1):
+                if (signed_magnitude_integer):
+                    value = -(value & (maxint >> 1)) * scale
+                else:
+                    value = (value - maxint) * scale
             else:
                 value = value * scale
 
@@ -92,7 +97,7 @@ class ParameterParser:
                 self.result[title] = value
 
         return
-    
+
     def try_parse_unsigned (self, rawData, definition, start, length):
         title = definition['name']
         scale = definition['scale'] if 'scale' in definition else 1

--- a/customization.md
+++ b/customization.md
@@ -113,15 +113,16 @@ Example yaml file for the mentioned above:
 ### Rule
 The `rule` field specifies how to interpret the binary data contained in the register(s).
 
-| Rule # | Description           | Example                                                                                                                |
-|--------|-----------------------|------------------------------------------------------------------------------------------------------------------------|
-|    1   | Unsigned 16-bit value |                                                                                                                        |
-|    2   | Signed 16 bit value   |                                                                                                                        |
-|    3   | Unsigned 32 bit value |                                                                                                                        |
-|    4   | Signed 32 bit value   |                                                                                                                        |
-|    5   | ASCII value           |                                                                                                                        |
-|    6   | Bit field             |                                                                                                                        |
-|    7   | Version               |                                                                                                                        |
-|    8   | Date Time             |                                                                                                                        |
-|    9   | Time                  | Time value as string<ul><li>Example 1: Register Value 2200 => Time Value: 22:00</li><li>Example 2: Register value: 400 => 04:00</li></ul>|
+| Rule # | Description            | Example                                                                                                                |
+|--------|------------------------|------------------------------------------------------------------------------------------------------------------------|
+|    1   | Unsigned 16 bit value  |                                                                                                                        |
+|    2   | Signed 16 bit value    |                                                                                                                        |
+|    3   | Unsigned 32 bit value  |                                                                                                                        |
+|    4   | Signed 32 bit value    |                                                                                                                        |
+|    5   | ASCII value            |                                                                                                                        |
+|    6   | Bit field              |                                                                                                                        |
+|    7   | Version                |                                                                                                                        |
+|    8   | Date Time              |                                                                                                                        |
+|    9   | Time                   | Time value as string<ul><li>Example 1: Register Value 2200 => Time Value: 22:00</li><li>Example 2: Register value: 400 => 04:00</li></ul>|
+|   10   | Signed magnitude value |                                                                                                                        |
 


### PR DESCRIPTION
Hello,

This commit adds support for Solarman Smart Meter DTSD422-D3. Since this device uses signed magnitude integer values I also had to add a parser for them.

I tested everything with my Home Assistant ant it seemed to work perfectly fine. For the moment I added all values besides the integrated energy values because the binary output shows a lot of values I cannot allocate to any meaningful information which is why I ommited them to not add some wrong information.

This PR fixes #451 and #520.

IMPORTANT QUESTION: I realized that the original signed integer parser is written for one's complement signed integers which I find astonishing since usually two's complement signed integers are used. Was this confirmed that Solarman devices actually use one's complement signed integers? Otherwise all negative values have an offset of -1.