### PR TITLE
Add new raw parser

### DIFF
--- a/custom_components/solarman/inverter_definitions/solis_hybrid.yaml
+++ b/custom_components/solarman/inverter_definitions/solis_hybrid.yaml
@@ -4,7 +4,7 @@
 # https://www.scss.tcd.ie/Brian.Coghlan/Elios4you/RS485_MODBUS-Hybrid-BACoghlan-201811228-1854.pdf
 
 requests:
-  - start: 33029
+  - start: 33022
     end:  33095
     mb_functioncode: 0x04
   - start: 33116
@@ -319,6 +319,15 @@ parameters:
       rule: 2
       registers: [33093]
       icon: 'mdi:thermometer'
+
+    - name: "Inverter Datetime Array"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 10
+      registers: [33022,33023,33024,33025,33026,33027]
+      icon: 'mdi:calendar-clock'
 
 # Sensors below are outside of modbus request ranges.
 # If enabling, ensure to amend the request start register.

--- a/custom_components/solarman/parser.py
+++ b/custom_components/solarman/parser.py
@@ -36,6 +36,8 @@ class ParameterParser:
             self.try_parse_datetime(rawData,definition, start, length)
         elif rule == 9:
             self.try_parse_time(rawData,definition, start, length)
+        elif rule == 10:
+            self.try_parse_raw(rawData,definition, start, length)
         return
     
     def do_validate(self, title, value, rule):
@@ -172,6 +174,22 @@ class ParameterParser:
         if found:
             self.result[title] = value
         return 
+
+    def try_parse_raw (self, rawData, definition, start, length):
+        title = definition['name']
+        found = True
+        value = []
+        for r in definition['registers']:
+            index = r - start   # get the decimal value of the register'
+            if (index >= 0) and (index < length):
+                temp = rawData[index]
+                value.append((temp))
+            else:
+                found = False
+
+        if found:
+            self.result[title] = value
+        return
     
     def try_parse_version (self, rawData, definition, start, length):
         title = definition['name']         

--- a/customization.md
+++ b/customization.md
@@ -124,4 +124,5 @@ The `rule` field specifies how to interpret the binary data contained in the reg
 |    7   | Version               |                                                                                                                        |
 |    8   | Date Time             |                                                                                                                        |
 |    9   | Time                  | Time value as string<ul><li>Example 1: Register Value 2200 => Time Value: 22:00</li><li>Example 2: Register value: 400 => 04:00</li></ul>|
+|   10   | Raw                   | Similar to Bit field without hex conversion. Useful where you need to read multiple  registers atomically              |
 


### PR DESCRIPTION
Read multiple registers and pass them through as array without
processing. Useful when you need to read multiple registers atomically.

For my usecase, I wanted to extract the inverter date time as a single
register to parse later using a jinja2 template.