### PR TITLE
Update and rename solis_hybrid.yaml to solis_hybrid-3P-(5-10)K-5G.yaml

### DIFF
--- a/custom_components/solarman/inverter_definitions/solis_hybrid--3P-(5-10)-5G.yaml
+++ b/custom_components/solarman/inverter_definitions/solis_hybrid--3P-(5-10)-5G.yaml
@@ -1,7 +1,7 @@
-# Solis Single Phase Hybrid
-# RHI-(3-6)K-48ES-5G
+# Solis three Phase Hybrid
+# RHI-(5-10)K HVES-5G
 # Modbus information retrieved from:
-# https://www.scss.tcd.ie/coghlan/Elios4you/RS485_MODBUS-Hybrid-BACoghlan-201811228-1854.pdf
+# https://www.scss.tcd.ie/Brian.Coghlan/Elios4you/RS485_MODBUS-Hybrid-BACoghlan-201811228-1854.pdf
 
 requests:
   - start: 33029
@@ -565,13 +565,40 @@ parameters:
       registers: [33252]
       icon: 'mdi:current-ac'
 
-    - name: "Meter Active Power"
+    - name: "Meter Active Power Phase A"
       class: "power"
       state_class: "measurement"
       uom: "W"
       scale: 1
       rule: 4
-      registers: [33258,33257]
+      registers: [33257]
+      icon: 'mdi:transmission-tower'
+
+    - name: "Meter Active Power Phase B"
+      class: "power"
+      state_class: "measurement"
+      uom: "W"
+      scale: 1
+      rule: 4
+      registers: [33259]
+      icon: 'mdi:transmission-tower'
+
+    - name: "Meter Active Power Phase C"
+      class: "power"
+      state_class: "measurement"
+      uom: "W"
+      scale: 1
+      rule: 4
+      registers: [33261]
+      icon: 'mdi:transmission-tower'
+
+    - name: "Meter Active Power Total"
+      class: "power"
+      state_class: "measurement"
+      uom: "W"
+      scale: 1
+      rule: 4
+      registers: [33263]
       icon: 'mdi:transmission-tower'
 
     - name: "Meter Reactive Power"


### PR DESCRIPTION
for Solis hybrid, 3 Phase, 5. Generation
necessary to have correct "grid total power" values, e.g. for other integrations as evcc,  etc.