### PR TITLE
added megarevo inverter definations

### DIFF
--- a/custom_components/solarman/inverter_definitions/megarevo_r15k3h.yaml
+++ b/custom_components/solarman/inverter_definitions/megarevo_r15k3h.yaml
@@ -1,0 +1,499 @@
+# Version: V0.1
+# Megarevo Inverters using Solarman v5 via Solarman App pcap - Full Register Map Not Complete Yet
+# Expected to Work with most of the Megarevo Inverters (including EG4 8k)
+# Tested with Megarevo R15K3H (3 Phase Hybird) with FW v0.01 and v1.0.13, some fields yet to be validated.
+# 
+# First: Aug 5, 2024 by wolfmon
+# Last: Aug 5, 2024 by wolfmon
+
+
+requests:
+  - start: 0x16A2
+    end:  0x16A2
+    mb_functioncode: 0x03
+  - start: 0x3110
+    end:  0x3189
+    mb_functioncode: 0x03
+  - start: 0x3190
+    end: 0x31A9
+    mb_functioncode: 0x03
+  - start: 0x3400
+    end: 0x3473
+    mb_functioncode: 0x03
+
+
+parameters:
+
+  - group: battery
+    items:
+    - name: "Battery Type"
+      state_class: "measurement"
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x340F]
+      isstr: true
+      lookup:
+        - key: 0
+          value: "Generic DC Source"
+        - key: 1
+          value: "Lead Acid (No BMS)"
+        - key: 2
+          value: "Lithium"
+
+    - name: "Battery Voltage (Inverter Terminal)"
+      class: "Voltage"
+      state_class: "measurement"
+      uom: "V"
+      scale: 0.1
+      rule: 1
+      registers: [0x3140]
+      icon: 'mdi:battery'
+    - name: "Battery Current (Inverter Terminal)"
+      class: "Current"
+      state_class: "measurement"
+      uom: "A"
+      scale: 0.1
+      rule: 2
+      registers: [0x3141]
+      icon: 'mdi:current-dc'
+    - name: "Battery Power (Inverter Terminal)"
+      class: "Watt"
+      state_class: "measurement"
+      uom: "W"
+      scale: 1
+      rule: 2
+      registers: [0x314A]
+      icon: 'mdi:power-plug'
+
+  - group: solar 
+    items:
+    - name: "PV Total Available Power"
+      class: "Watt"
+      state_class: "measurement"
+      uom: "W"
+      scale: 1
+      rule: 3
+      registers: [0x16A2]
+      icon: 'mdi:solar-power'
+
+    - name: "PV1 Voltage"
+      class: "Voltage"
+      state_class: "measurement"
+      uom: "V"
+      scale: 0.1
+      rule: 1
+      registers: [0x3130]
+      icon: 'mdi:solar-panel-large'
+    - name: "PV1 Current"
+      class: "Current"
+      state_class: "measurement"
+      uom: "A"
+      scale: 0.1
+      rule: 1
+      registers: [0x3131]
+      icon: 'mdi:current-dc'
+    - name: "PV1 Power"
+      class: "Watt"
+      state_class: "measurement"
+      uom: "W"
+      scale: 1
+      rule: 1
+      registers: [0x3132]
+      icon: 'mdi:solar-power'
+    
+    - name: "PV2 Voltage"
+      class: "Voltage"
+      state_class: "measurement"
+      uom: "V"
+      scale: 0.1
+      rule: 1
+      registers: [0x3133]
+      icon: 'mdi:solar-panel-large'
+    - name: "PV2 Current"
+      class: "Current"
+      state_class: "measurement"
+      uom: "A"
+      scale: 0.1
+      rule: 1
+      registers: [0x3134]
+      icon: 'mdi:current-dc'
+    - name: "PV2 Power"
+      class: "Watt"
+      state_class: "measurement"
+      uom: "W"
+      scale: 1
+      rule: 1
+      registers: [0x3135]
+      icon: 'mdi:solar-power'
+
+
+  - group: inverter 
+    items:
+    - name: "GFCI Leakage Current"
+      class: "Current"
+      state_class: "measurement"
+      uom: "mA"
+      scale: 1
+      rule: 1
+      registers: [0x319C]
+      icon: 'mdi:lightning-bolt-outline'
+
+    - name: "GFCI Leakage Current"
+      class: "Current"
+      state_class: "measurement"
+      uom: "mA"
+      scale: 1
+      rule: 1
+      registers: [0x319C]
+      icon: 'mdi:lightning-bolt-outline'
+
+    - name: "Inverter Mode"
+      class: "State"
+      state_class: "measurement"
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x3400]
+      isstr: true
+      lookup:
+        - key: 0
+          value: "Self-Consumption"
+        - key: 1
+          value: "Grid Peak Shift"
+        - key: 2
+          value: "Battery Priority (Storm Watch)"
+      icon: 'mdi:cog-outline'
+
+    - name: "Inverter Temperature-Enclosure"
+      class: "Temperature"
+      state_class: "measurement"
+      uom: "°C"
+      scale: 1
+      rule: 2
+      registers: [0x311A]
+      icon: 'mdi:thermometer'
+    
+    - name: "Inverter Temperature-Board"
+      class: "Temperature"
+      state_class: "measurement"
+      uom: "°C"
+      scale: 1
+      rule: 2
+      registers: [0x311B]
+      icon: 'mdi:thermometer'
+    
+    - name: "Total PV Generation (Day)"
+      class: "energy"
+      state_class: "total_increasing"
+      uom: "kWh"
+      scale: 0.001
+      rule: 3
+      registers: [0x3153]
+      icon: 'mdi:solar-power'
+    
+    - name: "Total Grid Purchase (Day)"
+      class: "energy"
+      state_class: "total_increasing"
+      uom: "kWh"
+      scale: 0.001
+      rule: 3
+      registers: [0x3155]
+      icon: 'mdi:transmission-tower'
+
+    - name: "Total Home Consumption (Day)"
+      class: "energy"
+      state_class: "total_increasing"
+      uom: "kWh"
+      scale: 0.001
+      rule: 3
+      registers: [0x3157]
+      icon: 'mdi:home'
+    
+    - name: "Total Battery Charge (Day)"
+      class: "energy"
+      state_class: "total_increasing"
+      uom: "kWh"
+      scale: 0.001
+      rule: 3
+      registers: [0x316D]
+      icon: 'mdi:battery-arrow-up-outline'
+    
+    - name: "Total Battery Discharge (Day)"
+      class: "energy"
+      state_class: "total_increasing"
+      uom: "kWh"
+      scale: 0.001
+      rule: 3
+      registers: [0x316F]
+      icon: 'mdi:battery-negative'
+
+    - name: "Total PV Generation (Lifetime)"
+      class: "energy"
+      state_class: "total_increasing"
+      uom: "kWh"
+      scale: 0.001
+      rule: 3
+      registers: [0x3165]
+      icon: 'mdi:solar-power'
+    
+    - name: "Total Grid Purchase (Lifetime)"
+      class: "energy"
+      state_class: "total_increasing"
+      uom: "kWh"
+      scale: 0.001
+      rule: 3
+      registers: [0x317D]
+      icon: 'mdi:transmission-tower'
+    
+    - name: "Total Grid Back-Feed (Lifetime)"
+      class: "energy"
+      state_class: "total_increasing"
+      uom: "kWh"
+      scale: 0.001
+      rule: 3
+      registers: [0x3167]
+      icon: 'mdi:transmission-tower'
+
+    - name: "Total Home Consumption (Lifetime)"
+      class: "energy"
+      state_class: "total_increasing"
+      uom: "kWh"
+      scale: 0.001
+      rule: 3
+      registers: [0x3169]
+      icon: 'mdi:home'
+    
+    - name: "Total Battery Charge (Lifetime)"
+      class: "energy"
+      state_class: "total_increasing"
+      uom: "kWh"
+      scale: 0.001
+      rule: 3
+      registers: [0x317F]
+      icon: 'mdi:battery-arrow-up-outline'
+    
+    - name: "Total Battery Discharge (Lifetime)"
+      class: "energy"
+      state_class: "total_increasing"
+      uom: "kWh"
+      scale: 0.001
+      rule: 3
+      registers: [0x3181]
+      icon: 'mdi:battery-negative'
+
+    - name: "Inverter Temperature-DC-DC"
+      class: "Temperature"
+      state_class: "measurement"
+      uom: "°C"
+      scale: 1
+      rule: 2
+      registers: [0x3152]
+      icon: 'mdi:thermometer'
+    
+
+  - group: grid
+    items: 
+    - name: "Grid Voltage - Phase A"
+      class: "Voltage"
+      state_class: "measurement"
+      uom: "V"
+      scale: 0.1
+      rule: 1
+      registers: [0x3110]
+      icon: 'mdi:transmission-tower'
+
+    - name: "Grid Current - Phase A"
+      class: "Current"
+      state_class: "measurement"
+      uom: "A"
+      scale: 0.1
+      rule: 2
+      registers: [0x3111]
+      icon: 'mdi:current-ac'
+
+    - name: "Grid Power - Phase A"
+      class: "Watt"
+      state_class: "measurement"
+      uom: "W"
+      scale: 1
+      rule: 2
+      registers: [0x3112]
+      icon: 'mdi:current-ac'
+    
+    - name: "Grid Voltage - Phase B"
+      class: "Voltage"
+      state_class: "measurement"
+      uom: "V"
+      scale: 0.1
+      rule: 1
+      registers: [0x3113]
+      icon: 'mdi:transmission-tower'
+
+    - name: "Grid Current - Phase B"
+      class: "Current"
+      state_class: "measurement"
+      uom: "A"
+      scale: 0.1
+      rule: 2
+      registers: [0x3114]
+      icon: 'mdi:current-ac'
+
+    - name: "Grid Power - Phase B"
+      class: "Watt"
+      state_class: "measurement"
+      uom: "W"
+      scale: 1
+      rule: 2
+      registers: [0x3115]
+      icon: 'mdi:current-ac'
+    
+    - name: "Grid Voltage - Phase C"
+      class: "Voltage"
+      state_class: "measurement"
+      uom: "V"
+      scale: 0.1
+      rule: 1
+      registers: [0x3116]
+      icon: 'mdi:transmission-tower'
+
+    - name: "Grid Current - Phase C"
+      class: "Current"
+      state_class: "measurement"
+      uom: "A"
+      scale: 0.1
+      rule: 2
+      registers: [0x3117]
+      icon: 'mdi:current-ac'
+
+    - name: "Grid Power - Phase C"
+      class: "Watt"
+      state_class: "measurement"
+      uom: "W"
+      scale: 1
+      rule: 2
+      registers: [0x3118]
+      icon: 'mdi:current-ac'
+    
+    - name: "Grid Frequency"
+      class: "Frequency"
+      state_class: "measurement"
+      uom: "Hz"
+      scale: 0.01
+      rule: 2
+      registers: [0x3119]
+      icon: 'mdi:current-ac'
+
+  - group: load
+    items: 
+    - name: "Load Voltage - Phase A"
+      class: "Voltage"
+      state_class: "measurement"
+      uom: "V"
+      scale: 0.1
+      rule: 1
+      registers: [0x3120]
+      icon: 'mdi:power-plug'
+
+    - name: "Load Current - Phase A"
+      class: "Current"
+      state_class: "measurement"
+      uom: "A"
+      scale: 0.1
+      rule: 1
+      registers: [0x3121]
+      icon: 'mdi:current-ac'
+
+    - name: "Load Power - Phase A"
+      class: "Watt"
+      state_class: "measurement"
+      uom: "W"
+      scale: 1
+      rule: 1
+      registers: [0x3122]
+      icon: 'mdi:current-ac'
+    
+    - name: "Load Capacity Used - Phase A"
+      class: "Percent"
+      state_class: "measurement"
+      uom: "%"
+      scale: 0.1
+      rule: 1
+      registers: [0x3123]
+      icon: 'mdi:fuse'
+    
+    - name: "Load Voltage - Phase B"
+      class: "Voltage"
+      state_class: "measurement"
+      uom: "V"
+      scale: 0.1
+      rule: 1
+      registers: [0x3124]
+      icon: 'mdi:power-plug'
+
+    - name: "Load Current - Phase B"
+      class: "Current"
+      state_class: "measurement"
+      uom: "A"
+      scale: 0.1
+      rule: 1
+      registers: [0x3125]
+      icon: 'mdi:current-ac'
+
+    - name: "Load Power - Phase B"
+      class: "Watt"
+      state_class: "measurement"
+      uom: "W"
+      scale: 1
+      rule: 1
+      registers: [0x3126]
+      icon: 'mdi:current-ac'
+    
+    - name: "Load Capacity Used - Phase B"
+      class: "Percent"
+      state_class: "measurement"
+      uom: "%"
+      scale: 0.1
+      rule: 1
+      registers: [0x3127]
+      icon: 'mdi:fuse'
+  
+    - name: "Load Voltage - Phase C"
+      class: "Voltage"
+      state_class: "measurement"
+      uom: "V"
+      scale: 0.1
+      rule: 1
+      registers: [0x3128]
+      icon: 'mdi:power-plug'
+
+    - name: "Load Current - Phase C"
+      class: "Current"
+      state_class: "measurement"
+      uom: "A"
+      scale: 0.1
+      rule: 1
+      registers: [0x3129]
+      icon: 'mdi:current-ac'
+
+    - name: "Load Power - Phase C"
+      class: "Watt"
+      state_class: "measurement"
+      uom: "W"
+      scale: 1
+      rule: 1
+      registers: [0x312A]
+      icon: 'mdi:current-ac'
+    
+    - name: "Load Capacity Used - Phase C"
+      class: "Percent"
+      state_class: "measurement"
+      uom: "%"
+      scale: 0.1
+      rule: 1
+      registers: [0x312B]
+      icon: 'mdi:fuse'
+    
+    
+
+    


### PR DESCRIPTION
### Added Megarevo Inverter Defination
#### (Mostly via solarman app pcap, so might not be 100% accurate)
Confirmed most registers in this commit working on 15KW 3 phase hybrid model (R15k3H) with Solarman V5 Wifi Logger, more fields to be added and validated.
![image](https://github.com/user-attachments/assets/33948fba-9d4e-49f8-a7bf-3a1ce5af8a11)


### Sidenote: A potential interesting V2G/V2H/V2L feature this can enable:

Still a PoC, but I am able to get the inverter to relatively safely? to connect and disconnect an EV to be used as energy storage battery, EV HV battery can both be charged and discharged via inverter, tested with GB/T 20234 connector (maybe this will work with ChaDeMo too? yet to be tested), inverter has issue detecting disconnected battery: when battery is disconnected, inverter still tries to energize battery bus with **lethal DC voltage** (tires to charge battery), this can be addressed by enabling BMS communication on the inverter to inject a fault so the inverter will stop putting voltage on battery bus, this can be done with the following so that the connector and cable can be removed safely:
![image](https://github.com/user-attachments/assets/4cf30fc7-eba8-43a0-9a93-66a0983459bc)
![image](https://github.com/user-attachments/assets/1de91f32-b6f3-4758-af76-8ae2484e2dd8)

**USE PROPER PPE, THIS SETUP IS NOT 100% SAFE YET, DO NOT TRY THIS AT HOME**
```
`modbus.send_raw_modbus_frame_parsed(b"\x01\x10\x34\x0f\x00\x01\x02\x00\x02\x52\xad")`
# DEBUG:pysolarmanv5.pysolarmanv5:SENT: a5 1a 00 10 45 FF FF FF FF FF FF 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01 10 34 0f 00 01 02 00 02 52 ad f6 15 (changed a few random bits to redact my SN, checksum will not match)
# DEBUG:pysolarmanv5.pysolarmanv5:RECD: a5 16 00 10 15 FF FF FF FF FF FF 02 01 07 2b 06 00 ff 17 00 00 f7 08 91 66 01 10 34 0f 00 01 3f fa d3 15  (changed a few random bits to redact my SN, checksum will not match)
```

Inverter mode can also be changed to force charge the car HV battery via grid (storm watch mode) or only via PV (like Tesla's drive on sunshine), but was not able to write with the current HA_solarman service call, any help would be appreciated (maybe create an separate issue for this?).